### PR TITLE
Add specific help command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/HelpDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpDeleteCommand.java
@@ -1,0 +1,21 @@
+package seedu.address.logic.commands;
+
+import seedu.address.model.Model;
+
+/**
+ * Format full help instructions for every command for display.
+ */
+public class HelpDeleteCommand extends Command {
+
+    public static final String COMMAND_WORD = "help-delete";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions for delete command.\n"
+            + "Example: " + COMMAND_WORD;
+
+    public static final String SHOWING_HELP_MESSAGE = "Opened help window for delete command.";
+
+    @Override
+    public CommandResult execute(Model model) {
+        return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/HelpEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpEditCommand.java
@@ -1,0 +1,21 @@
+package seedu.address.logic.commands;
+
+import seedu.address.model.Model;
+
+/**
+ * Format full help instructions for every command for display.
+ */
+public class HelpEditCommand extends Command {
+
+    public static final String COMMAND_WORD = "help-edit";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions for edit command.\n"
+            + "Example: " + COMMAND_WORD;
+
+    public static final String SHOWING_HELP_MESSAGE = "Opened help window for edit command.";
+
+    @Override
+    public CommandResult execute(Model model) {
+        return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/HelpPoochMaintenanceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpPoochMaintenanceCommand.java
@@ -1,0 +1,22 @@
+package seedu.address.logic.commands;
+
+import seedu.address.model.Model;
+
+/**
+ * Format full help instructions for every command for display.
+ */
+public class HelpPoochMaintenanceCommand extends Command {
+
+    public static final String COMMAND_WORD = "help-poochmaintenance";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions"
+            + " for pooch-poochmaintenance command.\n"
+            + "Example: " + COMMAND_WORD;
+
+    public static final String SHOWING_HELP_MESSAGE = "Opened help window for pooch-maintenance command.";
+
+    @Override
+    public CommandResult execute(Model model) {
+        return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/HelpPoochStaffCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpPoochStaffCommand.java
@@ -1,0 +1,22 @@
+package seedu.address.logic.commands;
+
+import seedu.address.model.Model;
+
+/**
+ * Format full help instructions for every command for display.
+ */
+public class HelpPoochStaffCommand extends Command {
+
+    public static final String COMMAND_WORD = "help-poochstaff";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Shows program usage instructions for pooch-staff command.\n"
+            + "Example: " + COMMAND_WORD;
+
+    public static final String SHOWING_HELP_MESSAGE = "Opened help window for pooch-staff command.";
+
+    @Override
+    public CommandResult execute(Model model) {
+        return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/HelpPoochSupplierCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpPoochSupplierCommand.java
@@ -1,0 +1,22 @@
+package seedu.address.logic.commands;
+
+import seedu.address.model.Model;
+
+/**
+ * Format full help instructions for every command for display.
+ */
+public class HelpPoochSupplierCommand extends Command {
+
+    public static final String COMMAND_WORD = "help-poochsupplier";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Shows program usage instructions for pocch-supplier command.\n"
+            + "Example: " + COMMAND_WORD;
+
+    public static final String SHOWING_HELP_MESSAGE = "Opened help window for pooch-supplier command.";
+
+    @Override
+    public CommandResult execute(Model model) {
+        return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/HelpSearchCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpSearchCommand.java
@@ -1,0 +1,21 @@
+package seedu.address.logic.commands;
+
+import seedu.address.model.Model;
+
+/**
+ * Format full help instructions for every command for display.
+ */
+public class HelpSearchCommand extends Command {
+
+    public static final String COMMAND_WORD = "help-search";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions for search command.\n"
+            + "Example: " + COMMAND_WORD;
+
+    public static final String SHOWING_HELP_MESSAGE = "Opened help window for search command.";
+
+    @Override
+    public CommandResult execute(Model model) {
+        return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -19,6 +19,12 @@ import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.HelpDeleteCommand;
+import seedu.address.logic.commands.HelpEditCommand;
+import seedu.address.logic.commands.HelpPoochMaintenanceCommand;
+import seedu.address.logic.commands.HelpPoochStaffCommand;
+import seedu.address.logic.commands.HelpPoochSupplierCommand;
+import seedu.address.logic.commands.HelpSearchCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -88,6 +94,24 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case HelpPoochStaffCommand.COMMAND_WORD:
+            return new HelpPoochStaffCommand();
+
+        case HelpPoochSupplierCommand.COMMAND_WORD:
+            return new HelpPoochSupplierCommand();
+
+        case HelpPoochMaintenanceCommand.COMMAND_WORD:
+            return new HelpPoochMaintenanceCommand();
+
+        case HelpSearchCommand.COMMAND_WORD:
+            return new HelpSearchCommand();
+
+        case HelpDeleteCommand.COMMAND_WORD:
+            return new HelpDeleteCommand();
+
+        case HelpEditCommand.COMMAND_WORD:
+            return new HelpEditCommand();
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/ui/HelpDeleteWindow.java
+++ b/src/main/java/seedu/address/ui/HelpDeleteWindow.java
@@ -13,10 +13,14 @@ import seedu.address.commons.core.LogsCenter;
 /**
  * Controller for a help page
  */
-public class HelpWindow extends UiPart<Stage> {
+public class HelpDeleteWindow extends UiPart<Stage> {
 
     public static final String USERGUIDE_URL = "https://ay2324s2-cs2103t-w10-2.github.io/tp/UserGuide.html";
-    public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
+    public static final String HELP_MESSAGE = "Deletes the specified person from the Pooch Planner"
+            + "\n" + "" + "\n"
+            + "Format: /delete ; name : [name] "
+            + "\n" + "" + "\n"
+            + "Go to our UG for more information : " + USERGUIDE_URL;
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);
     private static final String FXML = "HelpWindow.fxml";
@@ -32,7 +36,7 @@ public class HelpWindow extends UiPart<Stage> {
      *
      * @param root Stage to use as the root of the HelpWindow.
      */
-    public HelpWindow(Stage root) {
+    public HelpDeleteWindow(Stage root) {
         super(FXML, root);
         helpMessage.setText(HELP_MESSAGE);
     }
@@ -40,7 +44,7 @@ public class HelpWindow extends UiPart<Stage> {
     /**
      * Creates a new HelpWindow.
      */
-    public HelpWindow() {
+    public HelpDeleteWindow() {
         this(new Stage());
     }
 

--- a/src/main/java/seedu/address/ui/HelpDeleteWindow.java
+++ b/src/main/java/seedu/address/ui/HelpDeleteWindow.java
@@ -11,7 +11,7 @@ import javafx.stage.Stage;
 import seedu.address.commons.core.LogsCenter;
 
 /**
- * Controller for a help page
+ * Controller for a help page.
  */
 public class HelpDeleteWindow extends UiPart<Stage> {
 
@@ -67,7 +67,8 @@ public class HelpDeleteWindow extends UiPart<Stage> {
      *     </ul>
      */
     public void show() {
-        logger.fine("Showing help page about the application.");
+        String loggerSuccessMsg = "Showing help page about the application.";
+        logger.fine(loggerSuccessMsg);
         getRoot().show();
         getRoot().centerOnScreen();
     }

--- a/src/main/java/seedu/address/ui/HelpEditWindow.java
+++ b/src/main/java/seedu/address/ui/HelpEditWindow.java
@@ -13,10 +13,14 @@ import seedu.address.commons.core.LogsCenter;
 /**
  * Controller for a help page
  */
-public class HelpWindow extends UiPart<Stage> {
+public class HelpEditWindow extends UiPart<Stage> {
 
     public static final String USERGUIDE_URL = "https://ay2324s2-cs2103t-w10-2.github.io/tp/UserGuide.html";
-    public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
+    public static final String HELP_MESSAGE = "Edit the fields of the specified person in the Pooch Planner"
+            + "\n" + "" + "\n"
+            + "Format: /edit ; name : [name] ; field { [field] : [value] } "
+            + "\n" + "" + "\n"
+            + "Go to our UG for more information : " + USERGUIDE_URL;
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);
     private static final String FXML = "HelpWindow.fxml";
@@ -32,7 +36,7 @@ public class HelpWindow extends UiPart<Stage> {
      *
      * @param root Stage to use as the root of the HelpWindow.
      */
-    public HelpWindow(Stage root) {
+    public HelpEditWindow(Stage root) {
         super(FXML, root);
         helpMessage.setText(HELP_MESSAGE);
     }
@@ -40,7 +44,7 @@ public class HelpWindow extends UiPart<Stage> {
     /**
      * Creates a new HelpWindow.
      */
-    public HelpWindow() {
+    public HelpEditWindow() {
         this(new Stage());
     }
 

--- a/src/main/java/seedu/address/ui/HelpEditWindow.java
+++ b/src/main/java/seedu/address/ui/HelpEditWindow.java
@@ -11,7 +11,7 @@ import javafx.stage.Stage;
 import seedu.address.commons.core.LogsCenter;
 
 /**
- * Controller for a help page
+ * Controller for a help page.
  */
 public class HelpEditWindow extends UiPart<Stage> {
 
@@ -67,7 +67,8 @@ public class HelpEditWindow extends UiPart<Stage> {
      *     </ul>
      */
     public void show() {
-        logger.fine("Showing help page about the application.");
+        String loggerSuccessMsg = "Showing help page about the application.";
+        logger.fine(loggerSuccessMsg);
         getRoot().show();
         getRoot().centerOnScreen();
     }

--- a/src/main/java/seedu/address/ui/HelpPoochMaintenanceWindow.java
+++ b/src/main/java/seedu/address/ui/HelpPoochMaintenanceWindow.java
@@ -11,7 +11,7 @@ import javafx.stage.Stage;
 import seedu.address.commons.core.LogsCenter;
 
 /**
- * Controller for a help page
+ * Controller for a help page.
  */
 public class HelpPoochMaintenanceWindow extends UiPart<Stage> {
 
@@ -68,7 +68,8 @@ public class HelpPoochMaintenanceWindow extends UiPart<Stage> {
      *     </ul>
      */
     public void show() {
-        logger.fine("Showing help page about the application.");
+        String loggerSuccessMsg = "Showing help page about the application.";
+        logger.fine(loggerSuccessMsg);
         getRoot().show();
         getRoot().centerOnScreen();
     }

--- a/src/main/java/seedu/address/ui/HelpPoochMaintenanceWindow.java
+++ b/src/main/java/seedu/address/ui/HelpPoochMaintenanceWindow.java
@@ -13,10 +13,15 @@ import seedu.address.commons.core.LogsCenter;
 /**
  * Controller for a help page
  */
-public class HelpWindow extends UiPart<Stage> {
+public class HelpPoochMaintenanceWindow extends UiPart<Stage> {
 
     public static final String USERGUIDE_URL = "https://ay2324s2-cs2103t-w10-2.github.io/tp/UserGuide.html";
-    public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
+    public static final String HELP_MESSAGE = "Adds a pooch maintenance to pooch planner"
+            + "\n" + "" + "\n"
+            + "Format:/pooch-maintenance ; name : [name] ; phone : [phone] ; address : [address] ;"
+            + " email : [email] ; skill : [skill] ; commission : [commission] ;"
+            + "\n" + "" + "\n"
+            + "Go to our UG for more information : " + USERGUIDE_URL;
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);
     private static final String FXML = "HelpWindow.fxml";
@@ -32,7 +37,7 @@ public class HelpWindow extends UiPart<Stage> {
      *
      * @param root Stage to use as the root of the HelpWindow.
      */
-    public HelpWindow(Stage root) {
+    public HelpPoochMaintenanceWindow(Stage root) {
         super(FXML, root);
         helpMessage.setText(HELP_MESSAGE);
     }
@@ -40,7 +45,7 @@ public class HelpWindow extends UiPart<Stage> {
     /**
      * Creates a new HelpWindow.
      */
-    public HelpWindow() {
+    public HelpPoochMaintenanceWindow() {
         this(new Stage());
     }
 

--- a/src/main/java/seedu/address/ui/HelpPoochStaffWindow.java
+++ b/src/main/java/seedu/address/ui/HelpPoochStaffWindow.java
@@ -13,10 +13,15 @@ import seedu.address.commons.core.LogsCenter;
 /**
  * Controller for a help page
  */
-public class HelpWindow extends UiPart<Stage> {
+public class HelpPoochStaffWindow extends UiPart<Stage> {
 
     public static final String USERGUIDE_URL = "https://ay2324s2-cs2103t-w10-2.github.io/tp/UserGuide.html";
-    public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
+    public static final String HELP_MESSAGE = "Adds a pooch staff to pooch planner"
+            + "\n" + "" + "\n"
+            + "Format: /pooch-staff ; name : [name] ; phone : [phone] ;"
+            + " address : [address] ; email : [email] ; salary : [salary] ; employment : [part/full] ; "
+            + "\n" + "" + "\n"
+            + "Go to our UG for more information : " + USERGUIDE_URL;
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);
     private static final String FXML = "HelpWindow.fxml";
@@ -32,7 +37,7 @@ public class HelpWindow extends UiPart<Stage> {
      *
      * @param root Stage to use as the root of the HelpWindow.
      */
-    public HelpWindow(Stage root) {
+    public HelpPoochStaffWindow(Stage root) {
         super(FXML, root);
         helpMessage.setText(HELP_MESSAGE);
     }
@@ -40,7 +45,7 @@ public class HelpWindow extends UiPart<Stage> {
     /**
      * Creates a new HelpWindow.
      */
-    public HelpWindow() {
+    public HelpPoochStaffWindow() {
         this(new Stage());
     }
 

--- a/src/main/java/seedu/address/ui/HelpPoochStaffWindow.java
+++ b/src/main/java/seedu/address/ui/HelpPoochStaffWindow.java
@@ -11,7 +11,7 @@ import javafx.stage.Stage;
 import seedu.address.commons.core.LogsCenter;
 
 /**
- * Controller for a help page
+ * Controller for a help page.
  */
 public class HelpPoochStaffWindow extends UiPart<Stage> {
 
@@ -68,7 +68,8 @@ public class HelpPoochStaffWindow extends UiPart<Stage> {
      *     </ul>
      */
     public void show() {
-        logger.fine("Showing help page about the application.");
+        String loggerSuccessMsg = "Showing help page about the application.";
+        logger.fine(loggerSuccessMsg);
         getRoot().show();
         getRoot().centerOnScreen();
     }

--- a/src/main/java/seedu/address/ui/HelpPoochSupplierWindow.java
+++ b/src/main/java/seedu/address/ui/HelpPoochSupplierWindow.java
@@ -13,10 +13,15 @@ import seedu.address.commons.core.LogsCenter;
 /**
  * Controller for a help page
  */
-public class HelpWindow extends UiPart<Stage> {
+public class HelpPoochSupplierWindow extends UiPart<Stage> {
 
     public static final String USERGUIDE_URL = "https://ay2324s2-cs2103t-w10-2.github.io/tp/UserGuide.html";
-    public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
+    public static final String HELP_MESSAGE = "Adds a pooch supplier to pooch planner"
+            + "\n" + "" + "\n"
+            + "/pooch-supplier ; name : [name] ; phone : [phone] ; address : [address] ;"
+            + " email : [email] ; product : [product] ; price : [price] ;"
+            + "\n" + "" + "\n"
+            + "Go to our UG for more information : " + USERGUIDE_URL;
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);
     private static final String FXML = "HelpWindow.fxml";
@@ -32,7 +37,7 @@ public class HelpWindow extends UiPart<Stage> {
      *
      * @param root Stage to use as the root of the HelpWindow.
      */
-    public HelpWindow(Stage root) {
+    public HelpPoochSupplierWindow(Stage root) {
         super(FXML, root);
         helpMessage.setText(HELP_MESSAGE);
     }
@@ -40,7 +45,7 @@ public class HelpWindow extends UiPart<Stage> {
     /**
      * Creates a new HelpWindow.
      */
-    public HelpWindow() {
+    public HelpPoochSupplierWindow() {
         this(new Stage());
     }
 

--- a/src/main/java/seedu/address/ui/HelpPoochSupplierWindow.java
+++ b/src/main/java/seedu/address/ui/HelpPoochSupplierWindow.java
@@ -11,7 +11,7 @@ import javafx.stage.Stage;
 import seedu.address.commons.core.LogsCenter;
 
 /**
- * Controller for a help page
+ * Controller for a help page.
  */
 public class HelpPoochSupplierWindow extends UiPart<Stage> {
 
@@ -68,7 +68,8 @@ public class HelpPoochSupplierWindow extends UiPart<Stage> {
      *     </ul>
      */
     public void show() {
-        logger.fine("Showing help page about the application.");
+        String loggerSuccessMsg = "Showing help page about the application.";
+        logger.fine(loggerSuccessMsg);
         getRoot().show();
         getRoot().centerOnScreen();
     }

--- a/src/main/java/seedu/address/ui/HelpSearchWindow.java
+++ b/src/main/java/seedu/address/ui/HelpSearchWindow.java
@@ -13,10 +13,21 @@ import seedu.address.commons.core.LogsCenter;
 /**
  * Controller for a help page
  */
-public class HelpWindow extends UiPart<Stage> {
+public class HelpSearchWindow extends UiPart<Stage> {
 
     public static final String USERGUIDE_URL = "https://ay2324s2-cs2103t-w10-2.github.io/tp/UserGuide.html";
-    public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
+    public static final String HELP_MESSAGE = "Searches through the address book using specified fields and keyword"
+            + "\n" + "" + "\n"
+            + "Formats:" + "\n"
+            + "/search ; name : [full/partial name]" + "\n"
+            + "/search ; phone : [full/partial phone]" + "\n"
+            + "/search ; address : [full/partial address]" + "\n"
+            + "/search ; email : [full/partial email]" + "\n"
+            + "/search ; product : [full/partial product name]" + "\n"
+            + "/search ; employment : [employment]" + "\n"
+            + " address : [address] ; email : [email] ; salary : [salary] ; employment : [part/full] ; "
+            + "\n" + "" + "\n"
+            + "Go to our UG for more information : " + USERGUIDE_URL;
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);
     private static final String FXML = "HelpWindow.fxml";
@@ -32,7 +43,7 @@ public class HelpWindow extends UiPart<Stage> {
      *
      * @param root Stage to use as the root of the HelpWindow.
      */
-    public HelpWindow(Stage root) {
+    public HelpSearchWindow(Stage root) {
         super(FXML, root);
         helpMessage.setText(HELP_MESSAGE);
     }
@@ -40,7 +51,7 @@ public class HelpWindow extends UiPart<Stage> {
     /**
      * Creates a new HelpWindow.
      */
-    public HelpWindow() {
+    public HelpSearchWindow() {
         this(new Stage());
     }
 

--- a/src/main/java/seedu/address/ui/HelpSearchWindow.java
+++ b/src/main/java/seedu/address/ui/HelpSearchWindow.java
@@ -11,7 +11,7 @@ import javafx.stage.Stage;
 import seedu.address.commons.core.LogsCenter;
 
 /**
- * Controller for a help page
+ * Controller for a help page.
  */
 public class HelpSearchWindow extends UiPart<Stage> {
 
@@ -74,7 +74,8 @@ public class HelpSearchWindow extends UiPart<Stage> {
      *     </ul>
      */
     public void show() {
-        logger.fine("Showing help page about the application.");
+        String loggerSuccessMsg = "Showing help page about the application.";
+        logger.fine(loggerSuccessMsg);
         getRoot().show();
         getRoot().centerOnScreen();
     }

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -11,7 +11,7 @@ import javafx.stage.Stage;
 import seedu.address.commons.core.LogsCenter;
 
 /**
- * Controller for a help page
+ * Controller for a help page.
  */
 public class HelpWindow extends UiPart<Stage> {
 
@@ -63,7 +63,8 @@ public class HelpWindow extends UiPart<Stage> {
      *     </ul>
      */
     public void show() {
-        logger.fine("Showing help page about the application.");
+        String loggerSuccessMsg = "Showing help page about the application.";
+        logger.fine(loggerSuccessMsg);
         getRoot().show();
         getRoot().centerOnScreen();
     }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -14,6 +14,13 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.HelpDeleteCommand;
+import seedu.address.logic.commands.HelpEditCommand;
+import seedu.address.logic.commands.HelpPoochMaintenanceCommand;
+import seedu.address.logic.commands.HelpPoochStaffCommand;
+import seedu.address.logic.commands.HelpPoochSupplierCommand;
+import seedu.address.logic.commands.HelpSearchCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -34,6 +41,12 @@ public class MainWindow extends UiPart<Stage> {
     private PersonListPanel personListPanel;
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
+    private HelpPoochStaffWindow helpPoochStaffWindow;
+    private HelpPoochSupplierWindow helpPoochSupplierWindow;
+    private HelpPoochMaintenanceWindow helpPoochMaintenanceWindow;
+    private HelpDeleteWindow helpDeleteWindow;
+    private HelpEditWindow helpEditWindow;
+    private HelpSearchWindow helpSearchWindow;
 
     @FXML
     private StackPane commandBoxPlaceholder;
@@ -66,6 +79,12 @@ public class MainWindow extends UiPart<Stage> {
         setAccelerators();
 
         helpWindow = new HelpWindow();
+        helpPoochStaffWindow = new HelpPoochStaffWindow();
+        helpPoochSupplierWindow = new HelpPoochSupplierWindow();
+        helpPoochMaintenanceWindow = new HelpPoochMaintenanceWindow();
+        helpDeleteWindow = new HelpDeleteWindow();
+        helpEditWindow = new HelpEditWindow();
+        helpSearchWindow = new HelpSearchWindow();
     }
 
     public Stage getPrimaryStage() {
@@ -147,6 +166,54 @@ public class MainWindow extends UiPart<Stage> {
         }
     }
 
+    /**
+     * Opens the help poochstaff window or focuses on it if it's already opened.
+     */
+    @FXML
+    public void handlePoochStaffHelp() {
+        helpPoochStaffWindow.show();
+    }
+
+    /**
+     * Opens the help poochsupplier window or focuses on it if it's already opened.
+     */
+    @FXML
+    public void handlePoochSupplierHelp() {
+        helpPoochSupplierWindow.show();
+    }
+
+    /**
+     * Opens the help delete window or focuses on it if it's already opened.
+     */
+    @FXML
+    public void handleDeleteHelp() {
+        helpDeleteWindow.show();
+    }
+
+    /**
+     * Opens the help edit window or focuses on it if it's already opened.
+     */
+    @FXML
+    public void handleEditHelp() {
+        helpEditWindow.show();
+    }
+
+    /**
+     * Opens the help search window or focuses on it if it's already opened.
+     */
+    @FXML
+    public void handleSearchHelp() {
+        helpSearchWindow.show();
+    }
+
+    /**
+     * Opens the help pooch maintenance window or focuses on it if it's already opened.
+     */
+    @FXML
+    public void handlePoochMaintenanceHelp() {
+        helpPoochMaintenanceWindow.show();
+    }
+
     void show() {
         primaryStage.show();
     }
@@ -178,10 +245,28 @@ public class MainWindow extends UiPart<Stage> {
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
 
-            if (commandResult.isShowHelp()) {
+            if (commandResult.isShowHelp() && commandResult.getFeedbackToUser()
+                    .equals(HelpCommand.SHOWING_HELP_MESSAGE)) {
                 handleHelp();
+            } else if (commandResult.isShowHelp() && commandResult.getFeedbackToUser()
+                    .equals(HelpPoochStaffCommand.SHOWING_HELP_MESSAGE)) {
+                handlePoochStaffHelp();
+            } else if (commandResult.isShowHelp() && commandResult.getFeedbackToUser()
+                    .equals(HelpPoochSupplierCommand.SHOWING_HELP_MESSAGE)) {
+                handlePoochSupplierHelp();
+            } else if (commandResult.isShowHelp() && commandResult.getFeedbackToUser()
+                    .equals(HelpDeleteCommand.SHOWING_HELP_MESSAGE)) {
+                handleDeleteHelp();
+            } else if (commandResult.isShowHelp() && commandResult.getFeedbackToUser()
+                    .equals(HelpEditCommand.SHOWING_HELP_MESSAGE)) {
+                handleEditHelp();
+            } else if (commandResult.isShowHelp() && commandResult.getFeedbackToUser()
+                    .equals(HelpSearchCommand.SHOWING_HELP_MESSAGE)) {
+                handleSearchHelp();
+            } else if (commandResult.isShowHelp() && commandResult.getFeedbackToUser()
+                    .equals(HelpPoochMaintenanceCommand.SHOWING_HELP_MESSAGE)) {
+                handlePoochMaintenanceHelp();
             }
-
             if (commandResult.isExit()) {
                 handleExit();
             }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -245,26 +245,36 @@ public class MainWindow extends UiPart<Stage> {
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
 
-            if (commandResult.isShowHelp() && commandResult.getFeedbackToUser()
-                    .equals(HelpCommand.SHOWING_HELP_MESSAGE)) {
+            String userFeedback = commandResult.getFeedbackToUser();
+            Boolean isHelpCommand = commandResult.isShowHelp()
+                    && userFeedback.equals(HelpCommand.SHOWING_HELP_MESSAGE);
+            Boolean isPoochStaffHelpCommand = commandResult.isShowHelp()
+                    && userFeedback.equals(HelpPoochStaffCommand.SHOWING_HELP_MESSAGE);
+            Boolean isPoochMaintenanceHelpCommand = commandResult.isShowHelp()
+                    && userFeedback.equals(HelpPoochMaintenanceCommand.SHOWING_HELP_MESSAGE);
+            Boolean isPoochSupplierHelpCommand = commandResult.isShowHelp()
+                    && userFeedback.equals(HelpPoochSupplierCommand.SHOWING_HELP_MESSAGE);
+            Boolean isDeleteHelpCommand = commandResult.isShowHelp()
+                    && userFeedback.equals(HelpDeleteCommand.SHOWING_HELP_MESSAGE);
+            Boolean isEditHelpCommand = commandResult.isShowHelp()
+                    && userFeedback.equals(HelpEditCommand.SHOWING_HELP_MESSAGE);
+            Boolean isSearchHelpCommand = commandResult.isShowHelp()
+                    && userFeedback.equals(HelpSearchCommand.SHOWING_HELP_MESSAGE);
+
+
+            if (isHelpCommand) {
                 handleHelp();
-            } else if (commandResult.isShowHelp() && commandResult.getFeedbackToUser()
-                    .equals(HelpPoochStaffCommand.SHOWING_HELP_MESSAGE)) {
+            } else if (isPoochStaffHelpCommand) {
                 handlePoochStaffHelp();
-            } else if (commandResult.isShowHelp() && commandResult.getFeedbackToUser()
-                    .equals(HelpPoochSupplierCommand.SHOWING_HELP_MESSAGE)) {
+            } else if (isPoochSupplierHelpCommand) {
                 handlePoochSupplierHelp();
-            } else if (commandResult.isShowHelp() && commandResult.getFeedbackToUser()
-                    .equals(HelpDeleteCommand.SHOWING_HELP_MESSAGE)) {
+            } else if (isDeleteHelpCommand) {
                 handleDeleteHelp();
-            } else if (commandResult.isShowHelp() && commandResult.getFeedbackToUser()
-                    .equals(HelpEditCommand.SHOWING_HELP_MESSAGE)) {
+            } else if (isEditHelpCommand) {
                 handleEditHelp();
-            } else if (commandResult.isShowHelp() && commandResult.getFeedbackToUser()
-                    .equals(HelpSearchCommand.SHOWING_HELP_MESSAGE)) {
+            } else if (isSearchHelpCommand) {
                 handleSearchHelp();
-            } else if (commandResult.isShowHelp() && commandResult.getFeedbackToUser()
-                    .equals(HelpPoochMaintenanceCommand.SHOWING_HELP_MESSAGE)) {
+            } else if (isPoochMaintenanceHelpCommand) {
                 handlePoochMaintenanceHelp();
             }
             if (commandResult.isExit()) {

--- a/src/test/java/seedu/address/logic/commands/HelpDeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpDeleteCommandTest.java
@@ -1,0 +1,20 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.HelpDeleteCommand.SHOWING_HELP_MESSAGE;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+
+public class HelpDeleteCommandTest {
+    private Model model = new ModelManager();
+    private Model expectedModel = new ModelManager();
+
+    @Test
+    public void execute_deleteHelp_success() {
+        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        assertCommandSuccess(new HelpDeleteCommand(), model, expectedCommandResult, expectedModel);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/HelpEditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpEditCommandTest.java
@@ -1,0 +1,20 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.HelpEditCommand.SHOWING_HELP_MESSAGE;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+
+public class HelpEditCommandTest {
+    private Model model = new ModelManager();
+    private Model expectedModel = new ModelManager();
+
+    @Test
+    public void execute_editHelp_success() {
+        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        assertCommandSuccess(new HelpEditCommand(), model, expectedCommandResult, expectedModel);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/HelpPoochMaintenanceCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpPoochMaintenanceCommandTest.java
@@ -1,0 +1,20 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.HelpPoochMaintenanceCommand.SHOWING_HELP_MESSAGE;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+
+public class HelpPoochMaintenanceCommandTest {
+    private Model model = new ModelManager();
+    private Model expectedModel = new ModelManager();
+
+    @Test
+    public void execute_poochMaintenanceHelp_success() {
+        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        assertCommandSuccess(new HelpPoochMaintenanceCommand(), model, expectedCommandResult, expectedModel);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/HelpPoochStaffCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpPoochStaffCommandTest.java
@@ -1,0 +1,20 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.HelpPoochStaffCommand.SHOWING_HELP_MESSAGE;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+
+public class HelpPoochStaffCommandTest {
+    private Model model = new ModelManager();
+    private Model expectedModel = new ModelManager();
+
+    @Test
+    public void execute_poochStaffHelp_success() {
+        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        assertCommandSuccess(new HelpPoochStaffCommand(), model, expectedCommandResult, expectedModel);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/HelpPoochSupplierCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpPoochSupplierCommandTest.java
@@ -1,0 +1,20 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.HelpPoochSupplierCommand.SHOWING_HELP_MESSAGE;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+
+public class HelpPoochSupplierCommandTest {
+    private Model model = new ModelManager();
+    private Model expectedModel = new ModelManager();
+
+    @Test
+    public void execute_poochSupplierHelp_success() {
+        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        assertCommandSuccess(new HelpPoochSupplierCommand(), model, expectedCommandResult, expectedModel);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/HelpSearchCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpSearchCommandTest.java
@@ -1,0 +1,20 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.HelpSearchCommand.SHOWING_HELP_MESSAGE;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+
+public class HelpSearchCommandTest {
+    private Model model = new ModelManager();
+    private Model expectedModel = new ModelManager();
+
+    @Test
+    public void execute_searchHelp_success() {
+        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        assertCommandSuccess(new HelpSearchCommand(), model, expectedCommandResult, expectedModel);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -147,20 +147,25 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_helpPoochMaintenance() throws Exception {
-        assertTrue(parser.parseCommand(HelpPoochMaintenanceCommand.COMMAND_WORD) instanceof HelpPoochMaintenanceCommand);
-        assertTrue(parser.parseCommand(HelpPoochMaintenanceCommand.COMMAND_WORD + " 3") instanceof HelpPoochMaintenanceCommand);
+        assertTrue(parser.parseCommand(HelpPoochMaintenanceCommand.COMMAND_WORD)
+                instanceof HelpPoochMaintenanceCommand);
+        assertTrue(parser.parseCommand(HelpPoochMaintenanceCommand.COMMAND_WORD + " 3")
+                instanceof HelpPoochMaintenanceCommand);
     }
 
     @Test
     public void parseCommand_helpPoochSupplier() throws Exception {
-        assertTrue(parser.parseCommand(HelpPoochSupplierCommand.COMMAND_WORD) instanceof HelpPoochSupplierCommand);
-        assertTrue(parser.parseCommand(HelpPoochSupplierCommand.COMMAND_WORD + " 3") instanceof HelpPoochSupplierCommand);
+        assertTrue(parser.parseCommand(HelpPoochSupplierCommand.COMMAND_WORD)
+                instanceof HelpPoochSupplierCommand);
+        assertTrue(parser.parseCommand(HelpPoochSupplierCommand.COMMAND_WORD + " 3")
+                instanceof HelpPoochSupplierCommand);
     }
 
     @Test
     public void parseCommand_helpPoochStaff() throws Exception {
         assertTrue(parser.parseCommand(HelpPoochStaffCommand.COMMAND_WORD) instanceof HelpPoochStaffCommand);
-        assertTrue(parser.parseCommand(HelpPoochStaffCommand.COMMAND_WORD + " 3") instanceof HelpPoochStaffCommand);
+        assertTrue(parser.parseCommand(HelpPoochStaffCommand.COMMAND_WORD + " 3")
+                instanceof HelpPoochStaffCommand);
     }
 
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -24,6 +24,12 @@ import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.HelpDeleteCommand;
+import seedu.address.logic.commands.HelpEditCommand;
+import seedu.address.logic.commands.HelpPoochMaintenanceCommand;
+import seedu.address.logic.commands.HelpPoochStaffCommand;
+import seedu.address.logic.commands.HelpPoochSupplierCommand;
+import seedu.address.logic.commands.HelpSearchCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Maintainer;
@@ -122,6 +128,43 @@ public class AddressBookParserTest {
     }
 
     @Test
+    public void parseCommand_helpDelete() throws Exception {
+        assertTrue(parser.parseCommand(HelpDeleteCommand.COMMAND_WORD) instanceof HelpDeleteCommand);
+        assertTrue(parser.parseCommand(HelpDeleteCommand.COMMAND_WORD + " 3") instanceof HelpDeleteCommand);
+    }
+
+    @Test
+    public void parseCommand_helpEdit() throws Exception {
+        assertTrue(parser.parseCommand(HelpEditCommand.COMMAND_WORD) instanceof HelpEditCommand);
+        assertTrue(parser.parseCommand(HelpEditCommand.COMMAND_WORD + " 3") instanceof HelpEditCommand);
+    }
+
+    @Test
+    public void parseCommand_helpSearch() throws Exception {
+        assertTrue(parser.parseCommand(HelpSearchCommand.COMMAND_WORD) instanceof HelpSearchCommand);
+        assertTrue(parser.parseCommand(HelpSearchCommand.COMMAND_WORD + " 3") instanceof HelpSearchCommand);
+    }
+
+    @Test
+    public void parseCommand_helpPoochMaintenance() throws Exception {
+        assertTrue(parser.parseCommand(HelpPoochMaintenanceCommand.COMMAND_WORD) instanceof HelpPoochMaintenanceCommand);
+        assertTrue(parser.parseCommand(HelpPoochMaintenanceCommand.COMMAND_WORD + " 3") instanceof HelpPoochMaintenanceCommand);
+    }
+
+    @Test
+    public void parseCommand_helpPoochSupplier() throws Exception {
+        assertTrue(parser.parseCommand(HelpPoochSupplierCommand.COMMAND_WORD) instanceof HelpPoochSupplierCommand);
+        assertTrue(parser.parseCommand(HelpPoochSupplierCommand.COMMAND_WORD + " 3") instanceof HelpPoochSupplierCommand);
+    }
+
+    @Test
+    public void parseCommand_helpPoochStaff() throws Exception {
+        assertTrue(parser.parseCommand(HelpPoochStaffCommand.COMMAND_WORD) instanceof HelpPoochStaffCommand);
+        assertTrue(parser.parseCommand(HelpPoochStaffCommand.COMMAND_WORD + " 3") instanceof HelpPoochStaffCommand);
+    }
+
+
+    @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
         assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
             -> parser.parseCommand(""));
@@ -131,4 +174,5 @@ public class AddressBookParserTest {
     public void parseCommand_unknownCommand_throwsParseException() {
         assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
     }
+
 }


### PR DESCRIPTION
First-time users may be confused when
first using the application.

Specific help commands help users
easily find help for each specific command.

Create separate classes for each type of
command and a corresponding help window.

Fixes #55 