### PR TITLE
Fix edit command bugs

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -117,7 +117,7 @@ Format: `/edit-supplier ; name : [name] ; field : { phone : [phone] ; address : 
 
 
 #### Edits a maintainer
-Format: `/edit-supplier ; name : [name] ; field : { phone : [phone] ; address : [address] ; email : [email] ; skill : [skill] ; commission : [commission] }`
+Format: `/edit-maintainer ; name : [name] ; field : { phone : [phone] ; address : [address] ; email : [email] ; skill : [skill] ; commission : [commission] }`
 
 * Edits the specified `field`(s) of the person with the specified `name`. Note that the specified person must first exist in Pooch Contact Book.
 * The name is a compulsory field that is case-insensitive but space-sensitive.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -99,25 +99,39 @@ Constraints :
 * `For instance, to check whether a name is unique (case-insensitive), we parse in the .lower() String method to convert all fields to lowercase.`
 * `Name field is case-insensitive but space-sensitive`
 
-### Editing a person : `Edit`
+### Editing a contact : `Edit`
 
-Edit the fields of the specified person in the Pooch Planner.
+Edit the fields of the specified **person / staff / supplier / maintainer** in the Pooch Planner.
 
-Format: `/edit ; name : [name] ; field { [field] : [value] }`
+
+#### Edits a person
+Format: `/edit ; name : [name] ; field : { phone : [phone] ; address : [address] ; email : [email] }`
+
+
+#### Edits a staff
+Format: `/edit-staff ; name : [name] ; field : { phone : [phone] ; address : [address] ; email : [email] ; salary : [salary]  ; employment : [part/full] }`
+
+
+#### Edits a supplier
+Format: `/edit-supplier ; name : [name] ; field : { phone : [phone] ; address : [address] ; email : [email] ; product : [product] ; price : [price] }`
+
+
+#### Edits a maintainer
+Format: `/edit-supplier ; name : [name] ; field : { phone : [phone] ; address : [address] ; email : [email] ; skill : [skill] ; commission : [commission] }`
 
 * Edits the specified `field`(s) of the person with the specified `name`. Note that the specified person must first exist in Pooch Contact Book.
 * The name is a compulsory field that is case-insensitive but space-sensitive.
 * At least one field must be provided.
 * More than one field can be updated at the same time.
-* The field(s) to be edited must be a valid field within their contact type, i.e. Pooch Staff, Pooch Supplier, Pooch Maintenance).
-* **_Caution_** : Editing `name` field to another name that already exists in Pooch Contact Book is strictly **not** allowed.
+* The field(s) to be edited must be a valid field within their contact type, i.e. Pooch Staff, Pooch Supplier, Pooch Maintenance.
+* **_Caution_** : Editing `name` field is strictly **not** allowed and **will** be ignored.
 
 Examples:
 * `/edit ; name : Poochie ; field : { name : Mochie }`
 
   The above command edits the name of the person, from **_Poochie_** to **_Mochie_**, given that there are no other persons with the name, **_Mochie_**, in the Pooch Contact Book.
 
-* `/edit ; name : Thomas ; field : { address : Poochie Street 25 ; employment : full-time }`
+* `/edit-staff ; name : Thomas ; field : { address : Poochie Street 25 ; employment : full-time }`
 
   The above command edits the address of **_Thomas_** to **_Poochie Street 25_**.
   The above command also edits the employment of **_Thomas_**, which **must** be a **_Pooch Staff_**, to **_full-time_**.

--- a/docs/team/yleeyilin.md
+++ b/docs/team/yleeyilin.md
@@ -9,7 +9,7 @@ PoochPlanner is a desktop application to track details of various groups (vendor
 
 Given below are my contributions to the project.
 
-* **New Feature**: Added the ability to edit previous contacts.
+* **New Feature**: Added the ability to edit previous contacts. (Pull requests [\#62]())
   * What it does: allows the user to undo all previous commands one at a time. Preceding undo commands can be reversed by using the redo command.
   * Justification: This feature improves the product significantly because a user can make mistakes in commands and the app should provide a convenient way to rectify them.
   * Highlights: This enhancement affects existing commands and commands to be added in future. It required an in-depth analysis of design alternatives. The implementation too was challenging as it required changes to existing commands.

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -18,7 +18,15 @@ public class Messages {
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
-                "Multiple values specified for the following single-valued field(s): ";
+            "Multiple values specified for the following single-valued field(s): ";
+    public static final String MESSAGE_INVALID_EDIT_PERSON = "The name provided is invalid. \n "
+            + " Make sure that you are attempting to edit OTHERS.";
+    public static final String MESSAGE_INVALID_EDIT_STAFF = "The name provided is invalid. \n "
+            + "Make sure that you are attempting to edit STAFF.";
+    public static final String MESSAGE_INVALID_EDIT_MAINTAINER = "The name provided is invalid. \n "
+            + " Make sure that you are attempting to edit MAINTAINER.";
+    public static final String MESSAGE_INVALID_EDIT_SUPPLIER = "The name provided is invalid. \n "
+            + " Make sure that you are attempting to edit SUPPLIER.";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -13,7 +13,7 @@ import seedu.address.model.person.Person;
 public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
-    public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format!";
+    public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_NAME = "The name provided is invalid";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -40,11 +40,11 @@ public class EditCommand extends Command {
             + "[" + PREFIX_FIELD + "FIELD] "
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
-            + "[" + PREFIX_EMAIL + "EMAIL] "
+            + "[" + PREFIX_EMAIL + "EMAIL] \n"
             + "Example: " + COMMAND_WORD
             + PREFIX_NAME + "John Doe Others "
             + PREFIX_FIELD + "{ "
-            + PREFIX_NAME + "John Deed "
+            + "phone : " + "99820550 "
             + PREFIX_ADDRESS + "NUS College Avenue"
             + " }";
 

--- a/src/main/java/seedu/address/logic/commands/EditMaintainerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditMaintainerCommand.java
@@ -34,7 +34,7 @@ import seedu.address.model.tag.Tag;
  * Edits the details of an existing maintainer in the address book.
  */
 public class EditMaintainerCommand extends Command {
-    public static final String COMMAND_WORD = "/edit-maintenance";
+    public static final String COMMAND_WORD = "/edit-maintainer";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the maintainer identified "
             + "by the name used in the displayed person list.\n"

--- a/src/main/java/seedu/address/logic/commands/EditMaintainerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditMaintainerCommand.java
@@ -45,11 +45,11 @@ public class EditMaintainerCommand extends Command {
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_SKILL + "SKILL] "
-            + "[" + PREFIX_COMMISSION + "COMMISSION] "
+            + "[" + PREFIX_COMMISSION + "COMMISSION] \n"
             + "Example: " + COMMAND_WORD
-            + PREFIX_NAME + "John Doe Others "
+            + PREFIX_NAME + "John Doe Maintainer "
             + PREFIX_FIELD + "{ "
-            + PREFIX_NAME + "John Deed "
+            + "phone : " + "99820550 "
             + PREFIX_ADDRESS + "NUS College Avenue"
             + " }";
 

--- a/src/main/java/seedu/address/logic/commands/EditStaffCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditStaffCommand.java
@@ -46,14 +46,13 @@ public class EditStaffCommand extends Command {
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_SALARY + "SALARY] "
-            + "[" + PREFIX_EMPLOYMENT + "EMPLOYMENT] "
+            + "[" + PREFIX_EMPLOYMENT + "EMPLOYMENT] \n"
             + "Example: " + COMMAND_WORD
-            + PREFIX_NAME + "John Doe Others "
+            + PREFIX_NAME + "John Doe Staff "
             + PREFIX_FIELD + "{ "
-            + PREFIX_NAME + "John Deed "
+            + "phone : " + "99820550 "
             + PREFIX_ADDRESS + "NUS College Avenue"
             + " }";
-
     public static final String MESSAGE_EDIT_STAFF_SUCCESS = "Edited Staff: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_PERSON = "This staff's name already exists in the address book.";

--- a/src/main/java/seedu/address/logic/commands/EditSupplierCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditSupplierCommand.java
@@ -46,14 +46,13 @@ public class EditSupplierCommand extends Command {
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_PRODUCT + "PRODUCT] "
-            + "[" + PREFIX_PRICE + "PRICE] "
+            + "[" + PREFIX_PRICE + "PRICE] \n"
             + "Example: " + COMMAND_WORD
-            + PREFIX_NAME + "John Doe Others "
+            + PREFIX_NAME + "John Doe Supplier "
             + PREFIX_FIELD + "{ "
-            + PREFIX_NAME + "John Deed "
+            + "phone : " + "99820550 "
             + PREFIX_ADDRESS + "NUS College Avenue"
             + " }";
-
     public static final String MESSAGE_EDIT_SUPPLIER_SUCCESS = "Edited Supplier: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_SUPPLIER = "This supplier's name already exists in the address book.";

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
@@ -37,6 +38,10 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         Name name;
         String fieldArgs;
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_FIELD)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
+        }
 
         try {
             name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
@@ -67,6 +72,14 @@ public class EditCommandParser implements Parser<EditCommand> {
         editPersonDescriptor.setTags(tags);
 
         return new EditCommand(name, editPersonDescriptor);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/EditMaintainerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditMaintainerCommandParser.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import seedu.address.logic.commands.EditMaintainerCommand;
 import seedu.address.logic.commands.EditMaintainerCommand.EditMaintainerDescriptor;
@@ -39,6 +40,11 @@ public class EditMaintainerCommandParser implements Parser<EditMaintainerCommand
 
         Name name;
         String fieldArgs;
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_FIELD)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    EditMaintainerCommand.MESSAGE_USAGE));
+        }
 
         try {
             name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
@@ -74,6 +80,14 @@ public class EditMaintainerCommandParser implements Parser<EditMaintainerCommand
 
 
         return new EditMaintainerCommand(name, editMaintainerDescriptor);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/EditStaffCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditStaffCommandParser.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import seedu.address.logic.commands.EditStaffCommand;
 import seedu.address.logic.commands.EditStaffCommand.EditStaffDescriptor;
@@ -39,6 +40,10 @@ public class EditStaffCommandParser implements Parser<EditStaffCommand> {
 
         Name name;
         String fieldArgs;
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_FIELD)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditStaffCommand.MESSAGE_USAGE));
+        }
 
         try {
             name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
@@ -71,6 +76,14 @@ public class EditStaffCommandParser implements Parser<EditStaffCommand> {
         editStaffDescriptor.setTags(tags);
 
         return new EditStaffCommand(name, editStaffDescriptor);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/EditSupplierCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditSupplierCommandParser.java
@@ -15,7 +15,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
+import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditSupplierCommand;
 import seedu.address.logic.commands.EditSupplierCommand.EditSupplierDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -39,6 +41,10 @@ public class EditSupplierCommandParser implements Parser<EditSupplierCommand> {
 
         Name name;
         String fieldArgs;
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_FIELD)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
+        }
 
         try {
             name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
@@ -73,6 +79,14 @@ public class EditSupplierCommandParser implements Parser<EditSupplierCommand> {
 
 
         return new EditSupplierCommand(name, editSupplierDescriptor);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.person.Maintainer;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
@@ -93,27 +94,31 @@ public interface Model {
      * Find the person by their name.
      * @param targetName Refers to the name identifier.
      * @return Person that matches the name.
+     * @throws CommandException Handles invalid person message.
      */
-    Person findByName(Name targetName);
+    Person findByName(Name targetName) throws CommandException;
 
     /**
      * Find the maintainer by their name.
      * @param targetName Refers to the name identifier.
      * @return Maintainer that matches the name.
+     * @throws CommandException Handles invalid maintainer message.
      */
-    Maintainer findMaintainerByName(Name targetName);
+    Maintainer findMaintainerByName(Name targetName) throws CommandException;
 
     /**
      * Find the staff by their name.
      * @param targetName Refers to the name identifier.
      * @return Staff that matches the name.
+     * @throws CommandException Handles invalid staff message.
      */
-    Staff findStaffByName(Name targetName);
+    Staff findStaffByName(Name targetName) throws CommandException;
 
     /**
      * Find the supplier by their name.
      * @param targetName Refers to the name identifier.
      * @return Supplier that matches the name.
+     * @throws CommandException Handles invalid supplier message.
      */
-    Supplier findSupplierByName(Name targetName);
+    Supplier findSupplierByName(Name targetName) throws CommandException;
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,6 +11,8 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.person.Maintainer;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
@@ -153,13 +155,19 @@ public class ModelManager implements Model {
      * Find the person by their name.
      * @param targetName Refers to the name identifier.
      * @return Person that matches the name.
+     * @throws CommandException Handles invalid person message.
      */
     @Override
-    public Person findByName(Name targetName) {
+    public Person findByName(Name targetName) throws CommandException {
         for (Person person: filteredPersons) {
             Name name = person.getName();
             if (name.equals(targetName)) {
-                return person;
+                if (!(person instanceof Supplier) && !(person instanceof Staff)
+                        && !(person instanceof Maintainer)) {
+                    return person;
+                } else {
+                    throw new CommandException(Messages.MESSAGE_INVALID_EDIT_PERSON);
+                }
             }
         }
         return null;
@@ -169,13 +177,18 @@ public class ModelManager implements Model {
      * Find the maintainer by their name.
      * @param targetName Refers to the name identifier.
      * @return Maintainer that matches the name.
+     * @throws CommandException Handles invalid maintainer message.
      */
     @Override
-    public Maintainer findMaintainerByName(Name targetName) {
+    public Maintainer findMaintainerByName(Name targetName) throws CommandException {
         for (Person person: filteredPersons) {
             Name name = person.getName();
             if (name.equals(targetName) && person instanceof Maintainer) {
-                return (Maintainer) person;
+                if (person instanceof Maintainer) {
+                    return (Maintainer) person;
+                } else {
+                    throw new CommandException(Messages.MESSAGE_INVALID_EDIT_MAINTAINER);
+                }
             }
         }
         return null;
@@ -185,13 +198,18 @@ public class ModelManager implements Model {
      * Find the staff by their name.
      * @param targetName Refers to the name identifier.
      * @return Staff that matches the name.
+     * @throws CommandException Handles invalid staff message.
      */
     @Override
-    public Staff findStaffByName(Name targetName) {
+    public Staff findStaffByName(Name targetName) throws CommandException {
         for (Person person: filteredPersons) {
             Name name = person.getName();
-            if (name.equals(targetName) && person instanceof Staff) {
-                return (Staff) person;
+            if (name.equals(targetName)) {
+                if (person instanceof Staff) {
+                    return (Staff) person;
+                } else {
+                    throw new CommandException(Messages.MESSAGE_INVALID_EDIT_STAFF);
+                }
             }
         }
         return null;
@@ -201,13 +219,18 @@ public class ModelManager implements Model {
      * Find the supplier by their name.
      * @param targetName Refers to the name identifier.
      * @return Supplier that matches the name.
+     * @throws CommandException Handles invalid supplier message.
      */
     @Override
-    public Supplier findSupplierByName(Name targetName) {
+    public Supplier findSupplierByName(Name targetName) throws CommandException {
         for (Person person: filteredPersons) {
             Name name = person.getName();
-            if (name.equals(targetName) && person instanceof Supplier) {
-                return (Supplier) person;
+            if (name.equals(targetName)) {
+                if (person instanceof Supplier) {
+                    return (Supplier) person;
+                } else {
+                    throw new CommandException(Messages.MESSAGE_INVALID_EDIT_SUPPLIER);
+                }
             }
         }
         return null;

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -206,11 +206,17 @@ public class CommandTestUtil {
     public static void showPersonWithName(Model model, Name targetName) {
         assertTrue(targetName != null);
 
-        Person person = model.findByName(targetName);
-        final String[] splitName = person.getName().fullName.split("\\s+");
-        model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+        Person person;
 
-        assertEquals(1, model.getFilteredPersonList().size());
+        try {
+            person = model.findByName(targetName);
+            final String[] splitName = person.getName().fullName.split("\\s+");
+            model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+
+            assertEquals(1, model.getFilteredPersonList().size());
+        } catch (CommandException e) {
+            e.printStackTrace();
+        }
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -13,6 +13,7 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -45,17 +46,22 @@ public class DeleteCommandTest {
     public void execute_validNameFilteredList_success() {
         showPersonWithName(model, ALICE.getName());
 
-        Person personToDelete = model.findByName(ALICE.getName());
-        DeleteCommand deleteCommand = new DeleteCommand(ALICE.getName());
+        Person personToDelete;
+        try {
+            personToDelete = model.findByName(ALICE.getName());
+            DeleteCommand deleteCommand = new DeleteCommand(ALICE.getName());
 
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
-                Messages.format(personToDelete));
+            String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+                    Messages.format(personToDelete));
 
-        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
-        expectedModel.deletePerson(personToDelete);
-        showNoPerson(expectedModel);
+            Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+            expectedModel.deletePerson(personToDelete);
+            showNoPerson(expectedModel);
 
-        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+            assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+        } catch (CommandException e) {
+            e.printStackTrace();
+        }
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -43,7 +43,7 @@ public class EditCommandParserTest {
         // no field specified
         String userInput = EditCommand.COMMAND_WORD + " " + PREFIX_NAME + " "
             + " " + PREFIX_FIELD + "{" + " }";
-        assertParseFailure(parser, userInput, MESSAGE_INVALID_COMMAND_FORMAT);
+        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
     }
 
     @Test
@@ -52,7 +52,7 @@ public class EditCommandParserTest {
         String userInput = EditCommand.COMMAND_WORD + " " + PREFIX_NAME + " "
             + " " + PREFIX_FIELD + "{" + PHONE_DESC_AMY
             + ADDRESS_DESC_AMY + EMAIL_DESC_AMY + " }";
-        assertParseFailure(parser, userInput, MESSAGE_INVALID_COMMAND_FORMAT);
+        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
     }
 
     @Test
@@ -76,7 +76,7 @@ public class EditCommandParserTest {
         userInput = EditCommand.COMMAND_WORD + " " + PREFIX_NAME + "Person1"
             + " " + PREFIX_FIELD + "{" + INVALID_NAME_DESC + INVALID_EMAIL_DESC
             + VALID_ADDRESS_AMY + VALID_PHONE_AMY + " }";
-        assertParseFailure(parser, userInput, MESSAGE_INVALID_COMMAND_FORMAT);
+        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditMaintainerCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditMaintainerCommandParserTest.java
@@ -43,7 +43,8 @@ public class EditMaintainerCommandParserTest {
         // no field specified
         String userInput = EditMaintainerCommand.COMMAND_WORD + " " + PREFIX_NAME + " "
             + " " + PREFIX_FIELD + "{" + " }";
-        assertParseFailure(parser, userInput, MESSAGE_INVALID_COMMAND_FORMAT);
+        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                EditMaintainerCommand.MESSAGE_USAGE));
     }
 
     @Test
@@ -52,7 +53,8 @@ public class EditMaintainerCommandParserTest {
         String userInput = EditMaintainerCommand.COMMAND_WORD + " " + PREFIX_NAME + " "
             + " " + PREFIX_FIELD + "{" + PHONE_DESC_AMY
             + ADDRESS_DESC_AMY + EMAIL_DESC_AMY + " }";
-        assertParseFailure(parser, userInput, MESSAGE_INVALID_COMMAND_FORMAT);
+        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                EditMaintainerCommand.MESSAGE_USAGE));
     }
 
     @Test
@@ -76,7 +78,8 @@ public class EditMaintainerCommandParserTest {
         userInput = EditMaintainerCommand.COMMAND_WORD + " " + PREFIX_NAME + "Tom Tan1"
             + " " + PREFIX_FIELD + "{" + INVALID_NAME_DESC + INVALID_EMAIL_DESC
             + VALID_ADDRESS_AMY + VALID_PHONE_AMY + " }";
-        assertParseFailure(parser, userInput, MESSAGE_INVALID_COMMAND_FORMAT);
+        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                EditMaintainerCommand.MESSAGE_USAGE));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditStaffCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditStaffCommandParserTest.java
@@ -43,7 +43,8 @@ public class EditStaffCommandParserTest {
         // no field specified
         String userInput = EditStaffCommand.COMMAND_WORD + " " + PREFIX_NAME + " "
             + " " + PREFIX_FIELD + "{" + " }";
-        assertParseFailure(parser, userInput, MESSAGE_INVALID_COMMAND_FORMAT);
+        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                EditStaffCommand.MESSAGE_USAGE));
     }
 
     @Test
@@ -52,7 +53,8 @@ public class EditStaffCommandParserTest {
         String userInput = EditStaffCommand.COMMAND_WORD + " " + PREFIX_NAME + " "
             + " " + PREFIX_FIELD + "{" + PHONE_DESC_AMY
             + ADDRESS_DESC_AMY + EMAIL_DESC_AMY + " }";
-        assertParseFailure(parser, userInput, MESSAGE_INVALID_COMMAND_FORMAT);
+        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                EditStaffCommand.MESSAGE_USAGE));
     }
 
     @Test
@@ -76,7 +78,8 @@ public class EditStaffCommandParserTest {
         userInput = EditStaffCommand.COMMAND_WORD + " " + PREFIX_NAME + "Staff1"
             + " " + PREFIX_FIELD + "{" + INVALID_NAME_DESC + INVALID_EMAIL_DESC
             + VALID_ADDRESS_AMY + VALID_PHONE_AMY + " }";
-        assertParseFailure(parser, userInput, MESSAGE_INVALID_COMMAND_FORMAT);
+        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                EditStaffCommand.MESSAGE_USAGE));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditSupplierCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditSupplierCommandParserTest.java
@@ -43,7 +43,8 @@ public class EditSupplierCommandParserTest {
         // no field specified
         String userInput = EditSupplierCommand.COMMAND_WORD + " " + PREFIX_NAME + " "
             + " " + PREFIX_FIELD + "{" + " }";
-        assertParseFailure(parser, userInput, MESSAGE_INVALID_COMMAND_FORMAT);
+        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                EditSupplierCommand.MESSAGE_USAGE));
     }
 
     @Test
@@ -52,7 +53,8 @@ public class EditSupplierCommandParserTest {
         String userInput = EditSupplierCommand.COMMAND_WORD + " " + PREFIX_NAME + " "
             + " " + PREFIX_FIELD + "{" + PHONE_DESC_AMY
             + ADDRESS_DESC_AMY + EMAIL_DESC_AMY + " }";
-        assertParseFailure(parser, userInput, MESSAGE_INVALID_COMMAND_FORMAT);
+        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                EditSupplierCommand.MESSAGE_USAGE));
     }
 
     @Test
@@ -76,7 +78,8 @@ public class EditSupplierCommandParserTest {
         userInput = EditSupplierCommand.COMMAND_WORD + " " + PREFIX_NAME + "Supplier1"
             + " " + PREFIX_FIELD + "{" + INVALID_NAME_DESC + INVALID_EMAIL_DESC
             + VALID_ADDRESS_AMY + VALID_PHONE_AMY + " }";
-        assertParseFailure(parser, userInput, MESSAGE_INVALID_COMMAND_FORMAT);
+        assertParseFailure(parser, userInput, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                EditSupplierCommand.MESSAGE_USAGE));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.testutil.AddressBookBuilder;
 
@@ -130,6 +131,10 @@ public class ModelManagerTest {
         assertFalse(modelManager.equals(new ModelManager(addressBook, differentUserPrefs)));
 
         // finds a valid person by name
-        assertEquals(ALICE, modelManagerCopy.findByName(ALICE.getName()));
+        try {
+            assertEquals(ALICE, modelManagerCopy.findByName(ALICE.getName()));
+        } catch (CommandException e) {
+            e.printStackTrace();
+        }
     }
 }


### PR DESCRIPTION
Fixes #63 

Previously, having a mismatch between edit command and person
type will result in a change of person type, which should not happen.

This will lead to unexpected changes. 

I have handled the error to prevent these changes from happening. It 
was done by making sure that the user must use the right command
on the right type of person. I have also added the respective required
error handling messages.