### PR TITLE
Create Undo & Redo Command 

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -155,11 +155,11 @@ Classes used by multiple components are in the `seedu.addressbook.commons` packa
 
 This section describes some noteworthy details on how certain features are implemented.
 
-### \[Proposed\] Undo/redo feature
+### Undo/redo feature
 
-#### Proposed Implementation
+#### Implementation
 
-The proposed undo/redo mechanism is facilitated by `VersionedAddressBook`. It extends `AddressBook` with an undo/redo history, stored internally as an `addressBookStateList` and `currentStatePointer`. Additionally, it implements the following operations:
+The undo/redo mechanism is facilitated by `VersionedAddressBook`. It extends `AddressBook` with an undo/redo history, stored internally as an `addressBookStateList` and `currentStatePointer`. Additionally, it implements the following operations:
 
 * `VersionedAddressBook#commit()` — Saves the current address book state in its history.
 * `VersionedAddressBook#undo()` — Restores the previous address book state from its history.
@@ -228,16 +228,9 @@ The following activity diagram summarizes what happens when a user executes a ne
 
 **Aspect: How undo & redo executes:**
 
-* **Alternative 1 (current choice):** Saves the entire address book.
+* Saves the entire address book.
   * Pros: Easy to implement.
   * Cons: May have performance issues in terms of memory usage.
-
-* **Alternative 2:** Individual command knows how to undo/redo by
-  itself.
-  * Pros: Will use less memory (e.g. for `delete`, just save the person being deleted).
-  * Cons: We must ensure that the implementation of each individual command are correct.
-
-_{more aspects and alternatives to be added}_
 
 ### \[Proposed\] Data archiving
 
@@ -273,16 +266,18 @@ The app is optimised for use using Command Line Interface (CLI) while still enco
 
 Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unlikely to have) - `*`
 
-| Priority      | <div style="width:50px">As a …​</div>  | I want to …​                                               | So that I can…​                                       |
-|---------------|----------------------------------------|------------------------------------------------------------|-------------------------------------------------------|
-| `* * *`       | well connected user                    | search contacts                                            | save time                                             |
-| `* * *`       | well connected user                    | add contacts                                               | have the address to contact others in the future      |
-| `* * *`       | cafe owner user                        | delete the contacts of people                              | keep my contacts updated and remove outdated contacts |
-| `* * *`       | long-term user                         | edit contacts                                              | update some contact information                       |
-| `* * *`       | first-time user                        | get help about what commnads I can use on the contact book | easily know how to navigate the system                |
-| `**`          | frugal user                            | sort my vendors in ascending order of price                | view the vendors selling the cheapest products easily |
-| `**`          | careless user                          | undo my commands                                           | fix mistakes easily                                   |
-| `**`          | forgetful user                         | star contacts that are important                           | remember to contact them easily                       |
+| Priority      | <div style="width:50px">As a …​</div> | I want to …​                                               | So that I can…​                                       |
+|---------------|---------------------------------------|------------------------------------------------------------|-------------------------------------------------------|
+| `* * *`       | well connected user                   | search contacts                                            | save time                                             |
+| `* * *`       | well connected user                   | add contacts                                               | have the address to contact others in the future      |
+| `* * *`       | cafe owner user                       | delete the contacts of people                              | keep my contacts updated and remove outdated contacts |
+| `* * *`       | long-term user                        | edit contacts                                              | update some contact information                       |
+| `* * *`       | first-time user                       | get help about what commnads I can use on the contact book | easily know how to navigate the system                |
+| `**`          | frugal user                           | sort my vendors in ascending order of price                | view the vendors selling the cheapest products easily |
+| `**`          | careless user                         | undo my commands                                           | fix mistakes easily                                   |
+| `**`          | forgetful user                        | star contacts that are important                           | remember to contact them easily                       |
+| `**`          | careless user                         | undo previous command                                      | fix my mistakes easily                                |
+| `**`          | careless user                         | retrieve state before undo                                 | fix my mistakes easily                                |
 *{More to be added}*
 
 ### Use cases
@@ -489,6 +484,50 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
    * 1a2. User re-enters the command and request to learn about a valid command.
    * Steps 1a1 - 1a2 are repeated until a valid command is inputted by the User.
    * Use case resumes from step 2.
+
+---
+
+**System**: `PoochPlanner`
+
+**Use case**: `UC06 - Undo`
+
+**Actor**: `User`
+
+**MSS**:
+
+1.  User requests to undo previous command.
+2.  PoochPlanner retrieve previous state of address book.
+
+    Use case ends.
+
+**Extensions**:
+
+* 1a. PoochPlanner has no previous state of address book.
+
+    * 1a1. PoochPlanner displays the error message.
+    * Use case ends.
+
+---
+
+**System**: `PoochPlanner`
+
+**Use case**: `UC06 - Redo`
+
+**Actor**: `User`
+
+**MSS**:
+
+1.  User requests to redo.
+2.  PoochPlanner retrieve future state of address book.
+
+    Use case ends.
+
+**Extensions**:
+
+* 1a. PoochPlanner has no next state of address book.
+
+    * 1a1. PoochPlanner displays the error message.
+    * Use case ends.
 
 ---
 *{More to be added}*

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -212,6 +212,28 @@ Examples:
   The above command adds the note "meet poochie tonight to get kibble" to 
   the contact with name **_Poochie_**, provided **_Poochie_** exists as a name of a contact in Pooch Contact Book
 
+### Undo a command : `undo`
+
+Undo a previous command which made a change to Pooch Planner history.
+
+Format: `/undo`
+
+* Note that there is no parameter for this command
+* Any unnecessary parameter or value after /undo will simply be ignored.
+* This command unable to be executed when there is no more previous state.
+
+### Redo a command : `redo`
+
+Retrieve next state of Pooch Planner
+
+Format: `/redo`
+
+* Note that there is no parameter for this command
+* Any unnecessary parameter or value after /undo will simply be ignored.
+* This command unable to be executed when there is no next state.
+* This command only able to be executed when at least one undo command is executed.
+
+
 ### Exiting the program : `exit`
 
 Exits the program.
@@ -269,4 +291,6 @@ Action | Format, Examples
 **Help Delete** | `/help-delete`
 **Help Edit** | `/help-edit`
 **Help Search** | `/help-search`
+**Undo Command** | `/undo`
+**Redo Command** | `/redo`
 `

--- a/src/main/java/seedu/address/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoCommand.java
@@ -9,7 +9,7 @@ import seedu.address.model.Model;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Adds a person to the address book.
+ * Redo Command.
  */
 public class RedoCommand extends Command {
 
@@ -19,7 +19,7 @@ public class RedoCommand extends Command {
 
 
     /**
-     * Creates an AddCommand to add the specified {@code Person}
+     * Creates an RedoCommand.
      */
     public RedoCommand() {
     }

--- a/src/main/java/seedu/address/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoCommand.java
@@ -1,12 +1,11 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.messages.RedoMessages;
-import seedu.address.logic.messages.UndoMessages;
 import seedu.address.model.Model;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * Redo Command.

--- a/src/main/java/seedu/address/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoCommand.java
@@ -1,0 +1,58 @@
+package seedu.address.logic.commands;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.messages.RedoMessages;
+import seedu.address.logic.messages.UndoMessages;
+import seedu.address.model.Model;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Adds a person to the address book.
+ */
+public class RedoCommand extends Command {
+
+    public static final String COMMAND_WORD = "/redo";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Redo previous execution. ";
+
+
+    /**
+     * Creates an AddCommand to add the specified {@code Person}
+     */
+    public RedoCommand() {
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (!model.canRedo()) {
+            throw new CommandException(RedoMessages.MESSAGE_REDO_FAIL);
+        }
+
+        model.redoAddressBook();
+        return new CommandResult(RedoMessages.MESSAGE_REDO_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof RedoCommand)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -1,0 +1,63 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.messages.AddMessages;
+import seedu.address.logic.messages.UndoMessages;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
+/**
+ * Adds a person to the address book.
+ */
+public class UndoCommand extends Command {
+
+    public static final String COMMAND_WORD = "/undo";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Undo previous execution. ";
+
+
+    /**
+     * Creates an AddCommand to add the specified {@code Person}
+     */
+    public UndoCommand() {
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (!model.canUndo()) {
+            throw new CommandException(UndoMessages.MESSAGE_UNDO_FAIL);
+        }
+
+        model.undoAddressBook();
+        return new CommandResult(UndoMessages.MESSAGE_UNDO_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof UndoCommand)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -1,17 +1,11 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.logic.messages.AddMessages;
 import seedu.address.logic.messages.UndoMessages;
 import seedu.address.model.Model;
-import seedu.address.model.person.Person;
 
 /**
  * Undo Command.

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -14,7 +14,7 @@ import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 
 /**
- * Adds a person to the address book.
+ * Undo Command.
  */
 public class UndoCommand extends Command {
 
@@ -24,7 +24,7 @@ public class UndoCommand extends Command {
 
 
     /**
-     * Creates an AddCommand to add the specified {@code Person}
+     * Creates an UndoCommand.
      */
     public UndoCommand() {
     }

--- a/src/main/java/seedu/address/logic/messages/AddMessages.java
+++ b/src/main/java/seedu/address/logic/messages/AddMessages.java
@@ -6,7 +6,7 @@ import seedu.address.model.person.Staff;
 import seedu.address.model.person.Supplier;
 
 /**
- * Container for user delete command visible messages.
+ * Container for user add command visible messages.
  */
 public class AddMessages extends Messages {
     public static final String MESSAGE_ADD_PERSON_SUCCESS = "Woof! Added %1$s successfully! \uD83D\uDC36";

--- a/src/main/java/seedu/address/logic/messages/EditMessages.java
+++ b/src/main/java/seedu/address/logic/messages/EditMessages.java
@@ -6,7 +6,7 @@ import seedu.address.model.person.Staff;
 import seedu.address.model.person.Supplier;
 
 /**
- * Container for user delete command visible messages.
+ * Container for user edit command visible messages.
  */
 public class EditMessages extends Messages {
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Woof! Edited %1$s successfully! \uD83D\uDC36";

--- a/src/main/java/seedu/address/logic/messages/HelpMessages.java
+++ b/src/main/java/seedu/address/logic/messages/HelpMessages.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.messages;
 
 /**
- * Container for user delete command visible messages.
+ * Container for user help command visible messages.
  */
 public class HelpMessages extends Messages {
     public static final String MESSAGES_SHOWING_HELP_MESSAGE = "Opened help window.";

--- a/src/main/java/seedu/address/logic/messages/Messages.java
+++ b/src/main/java/seedu/address/logic/messages/Messages.java
@@ -14,6 +14,8 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
+    public static final String MESSAGE_INVALID_FIELD_FORMAT = "Invalid field detected : %1$s";
+    public static final String MESSAGE_COMMAND_FORMAT = "Follow this command format! \n%1$s";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
             "Multiple values specified for the following single-valued field(s): ";

--- a/src/main/java/seedu/address/logic/messages/NoteMessages.java
+++ b/src/main/java/seedu/address/logic/messages/NoteMessages.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.messages;
 
 /**
- * Container for user delete command visible messages.
+ * Container for user note command visible messages.
  */
 public class NoteMessages extends Messages {
     public static final String MESSAGE_ADD_NOTE_SUCCESS =

--- a/src/main/java/seedu/address/logic/messages/RedoMessages.java
+++ b/src/main/java/seedu/address/logic/messages/RedoMessages.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.messages;
 
 /**
- * Container for user delete command visible messages.
+ * Container for user redo command visible messages.
  */
 public class RedoMessages extends Messages {
     public static final String MESSAGE_REDO_SUCCESS = "Woof! Redo successfully! \uD83D\uDC36";

--- a/src/main/java/seedu/address/logic/messages/RedoMessages.java
+++ b/src/main/java/seedu/address/logic/messages/RedoMessages.java
@@ -1,0 +1,10 @@
+package seedu.address.logic.messages;
+
+/**
+ * Container for user delete command visible messages.
+ */
+public class RedoMessages extends Messages {
+    public static final String MESSAGE_REDO_SUCCESS = "Woof! Redo successfully! \uD83D\uDC36";
+    public static final String MESSAGE_REDO_FAIL = "Woof! There is no more future state to redo!";
+
+}

--- a/src/main/java/seedu/address/logic/messages/SearchMessages.java
+++ b/src/main/java/seedu/address/logic/messages/SearchMessages.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.messages;
 
 /**
- * Container for user delete command visible messages.
+ * Container for user search command visible messages.
  */
 public class SearchMessages extends Messages {
     public static final String MESSAGE_SEARCH_PERSON_SUCCESS = "Woof! %1$s contacts found! \uD83D\uDC36";

--- a/src/main/java/seedu/address/logic/messages/UndoMessages.java
+++ b/src/main/java/seedu/address/logic/messages/UndoMessages.java
@@ -1,10 +1,5 @@
 package seedu.address.logic.messages;
 
-import seedu.address.model.person.Maintainer;
-import seedu.address.model.person.Person;
-import seedu.address.model.person.Staff;
-import seedu.address.model.person.Supplier;
-
 /**
  * Container for user undo command visible messages.
  */

--- a/src/main/java/seedu/address/logic/messages/UndoMessages.java
+++ b/src/main/java/seedu/address/logic/messages/UndoMessages.java
@@ -6,7 +6,7 @@ import seedu.address.model.person.Staff;
 import seedu.address.model.person.Supplier;
 
 /**
- * Container for user delete command visible messages.
+ * Container for user undo command visible messages.
  */
 public class UndoMessages extends Messages {
     public static final String MESSAGE_UNDO_SUCCESS = "Woof! Undo successfully! \uD83D\uDC36";

--- a/src/main/java/seedu/address/logic/messages/UndoMessages.java
+++ b/src/main/java/seedu/address/logic/messages/UndoMessages.java
@@ -1,0 +1,15 @@
+package seedu.address.logic.messages;
+
+import seedu.address.model.person.Maintainer;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Staff;
+import seedu.address.model.person.Supplier;
+
+/**
+ * Container for user delete command visible messages.
+ */
+public class UndoMessages extends Messages {
+    public static final String MESSAGE_UNDO_SUCCESS = "Woof! Undo successfully! \uD83D\uDC36";
+    public static final String MESSAGE_UNDO_FAIL = "Woof! There is no more previous state to undo!";
+
+}

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.messages.Messages.MESSAGE_COMMAND_FORMAT;
 import static seedu.address.logic.messages.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.messages.Messages.MESSAGE_INVALID_FIELD_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -31,6 +33,15 @@ public class AddCommandParser implements Parser<AddCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public AddCommand parse(String args) throws ParseException {
+        String unknownPrefix = ArgumentTokenizer.checkUnknownPrefix(args,
+                PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
+
+        if (unknownPrefix != null) {
+            String exception = String.format(MESSAGE_INVALID_FIELD_FORMAT, unknownPrefix);
+            exception += "\n" + String.format(MESSAGE_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
+            throw new ParseException(exception);
+        }
+
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
 

--- a/src/main/java/seedu/address/logic/parser/AddMaintainerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddMaintainerCommandParser.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.messages.Messages.MESSAGE_COMMAND_FORMAT;
 import static seedu.address.logic.messages.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.messages.Messages.MESSAGE_INVALID_FIELD_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COMMISSION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
@@ -34,6 +36,16 @@ public class AddMaintainerCommandParser implements Parser<AddMaintainerCommand> 
      * @throws ParseException if the user input does not conform the expected format
      */
     public AddMaintainerCommand parse(String args) throws ParseException {
+        String unknownPrefix = ArgumentTokenizer.checkUnknownPrefix(args,
+                PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                PREFIX_SKILL, PREFIX_COMMISSION);
+
+        if (unknownPrefix != null) {
+            String exception = String.format(MESSAGE_INVALID_FIELD_FORMAT, unknownPrefix);
+            exception += "\n" + String.format(MESSAGE_COMMAND_FORMAT, AddMaintainerCommand.MESSAGE_USAGE);
+            throw new ParseException(exception);
+        }
+
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
                         PREFIX_SKILL, PREFIX_COMMISSION);

--- a/src/main/java/seedu/address/logic/parser/AddStaffCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddStaffCommandParser.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.messages.Messages.MESSAGE_COMMAND_FORMAT;
 import static seedu.address.logic.messages.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.messages.Messages.MESSAGE_INVALID_FIELD_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMPLOYMENT;
@@ -35,6 +37,16 @@ public class AddStaffCommandParser implements Parser<AddStaffCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public AddStaffCommand parse(String args) throws ParseException {
+        String unknownPrefix = ArgumentTokenizer.checkUnknownPrefix(args,
+                PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG,
+                PREFIX_SALARY, PREFIX_EMPLOYMENT);
+
+        if (unknownPrefix != null) {
+            String exception = String.format(MESSAGE_INVALID_FIELD_FORMAT, unknownPrefix);
+            exception += "\n" + String.format(MESSAGE_COMMAND_FORMAT, AddStaffCommand.MESSAGE_USAGE);
+            throw new ParseException(exception);
+        }
+
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG,
                         PREFIX_SALARY, PREFIX_EMPLOYMENT);

--- a/src/main/java/seedu/address/logic/parser/AddSupplierCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddSupplierCommandParser.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.messages.Messages.MESSAGE_COMMAND_FORMAT;
 import static seedu.address.logic.messages.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.messages.Messages.MESSAGE_INVALID_FIELD_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -34,6 +36,16 @@ public class AddSupplierCommandParser implements Parser<AddSupplierCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public AddSupplierCommand parse(String args) throws ParseException {
+        String unknownPrefix = ArgumentTokenizer.checkUnknownPrefix(args,
+                PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                PREFIX_PRODUCT, PREFIX_PRICE);
+
+        if (unknownPrefix != null) {
+            String exception = String.format(MESSAGE_INVALID_FIELD_FORMAT, unknownPrefix);
+            exception += "\n" + String.format(MESSAGE_COMMAND_FORMAT, AddSupplierCommand.MESSAGE_USAGE);
+            throw new ParseException(exception);
+        }
+
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
                         PREFIX_PRODUCT, PREFIX_PRICE);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -30,7 +30,9 @@ import seedu.address.logic.commands.HelpPoochSupplierCommand;
 import seedu.address.logic.commands.HelpSearchCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.NoteCommand;
+import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.SearchCommand;
+import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -132,6 +134,12 @@ public class AddressBookParser {
 
         case NoteCommand.COMMAND_WORD:
             return new NoteCommandParser().parse(arguments);
+
+        case UndoCommand.COMMAND_WORD:
+            return new UndoCommand();
+
+        case RedoCommand.COMMAND_WORD:
+            return new RedoCommand();
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -3,6 +3,8 @@ package seedu.address.logic.parser;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -26,6 +28,34 @@ public class ArgumentTokenizer {
     public static ArgumentMultimap tokenize(String argsString, Prefix... prefixes) {
         List<PrefixPosition> positions = findAllPrefixPositions(argsString, prefixes);
         return extractArguments(argsString, positions);
+    }
+
+    /**
+     * Checks whether exist unknown prefix.
+     * @param argsString Argument string that we want to check for unknwon prefix
+     * @param prefixes Prefixes that we accept
+     * @return unknown prefix string
+     */
+    public static String checkUnknownPrefix(String argsString, Prefix... prefixes) {
+        Pattern pattern = Pattern.compile(";\\s*([^:]+)\\s*:");
+        Matcher matcher = pattern.matcher(argsString);
+
+        while (matcher.find()) {
+            String foundPrefix = matcher.group(0);
+            boolean isKnownPrefix = false;
+
+            for (Prefix p : prefixes) {
+                if (p.getPrefix().trim().equals(foundPrefix)) {
+                    isKnownPrefix = true;
+                    break;
+                }
+            }
+
+            if (!isKnownPrefix) {
+                return foundPrefix;
+            }
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -121,4 +121,12 @@ public interface Model {
      * @throws CommandException Handles invalid supplier message.
      */
     Supplier findSupplierByName(Name targetName) throws CommandException;
+
+    void commitAddressBook();
+
+    void undoAddressBook();
+
+    void redoAddressBook();
+    boolean canUndo();
+    boolean canRedo();
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -122,11 +122,30 @@ public interface Model {
      */
     Supplier findSupplierByName(Name targetName) throws CommandException;
 
+    /**
+     * Commits new version of AddressBook into VersionedAddressBook Tracker.
+     */
     void commitAddressBook();
 
+    /**
+     * Retrieves previous version of AddressBook from VersionedAddressBook Tracker.
+     */
     void undoAddressBook();
 
+    /**
+     * Retrieves future version of AddressBook due to undo from VerssionedAddressBook Tracker.
+     */
     void redoAddressBook();
+
+    /**
+     * Returns a boolean value to indicate whether undo command is possible to be carried out.
+     * @return True if possible to undo, else False.
+     */
     boolean canUndo();
+
+    /**
+     * Returns a boolean value to indicate whether redo command is possible to be carried out.
+     * @return True if possible to redo, else False.
+     */
     boolean canRedo();
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -25,7 +25,7 @@ import seedu.address.model.person.Supplier;
 public class ModelManager implements Model {
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
 
-    private final AddressBook addressBook;
+    private final VersionedAddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
 
@@ -37,7 +37,7 @@ public class ModelManager implements Model {
 
         logger.fine("Initializing with address book: " + addressBook + " and user prefs " + userPrefs);
 
-        this.addressBook = new AddressBook(addressBook);
+        this.addressBook = new VersionedAddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
     }
@@ -102,11 +102,13 @@ public class ModelManager implements Model {
     @Override
     public void deletePerson(Person target) {
         addressBook.removePerson(target);
+        commitAddressBook();
     }
 
     @Override
     public void addPerson(Person person) {
         addressBook.addPerson(person);
+        commitAddressBook();
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
 
@@ -115,6 +117,32 @@ public class ModelManager implements Model {
         requireAllNonNull(target, editedPerson);
 
         addressBook.setPerson(target, editedPerson);
+        commitAddressBook();
+    }
+
+    @Override
+    public void commitAddressBook() {
+        addressBook.commit();
+    }
+
+    @Override
+    public void undoAddressBook() {
+        addressBook.undo();
+    }
+
+    @Override
+    public void redoAddressBook() {
+        addressBook.redo();
+    }
+
+    @Override
+    public boolean canUndo() {
+        return addressBook.canUndo();
+    }
+
+    @Override
+    public boolean canRedo() {
+        return addressBook.canRedo();
     }
 
     //=========== Filtered Person List Accessors =============================================================

--- a/src/main/java/seedu/address/model/VersionedAddressBook.java
+++ b/src/main/java/seedu/address/model/VersionedAddressBook.java
@@ -3,10 +3,17 @@ package seedu.address.model;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 
+/**
+ * Extended version of Address Book storing History of Address Book.
+ */
 public class VersionedAddressBook extends AddressBook {
     private ArrayList<ReadOnlyAddressBook> addressBookStateList ;
     int currentStatePointer;
 
+    /**
+     * Creates VersionedAddressBook and initialize addressBookStateList to track history.
+     * @param addressBook initial address book
+     */
     public VersionedAddressBook(ReadOnlyAddressBook addressBook) {
         super(addressBook);
 
@@ -15,17 +22,27 @@ public class VersionedAddressBook extends AddressBook {
         currentStatePointer = 0;
     }
 
+    /**
+     * Commits the new state of address book into tracker addressBookStateList.
+     */
     public void commit() {
         updateSubAddressBookStateList();
         this.addressBookStateList.add(new AddressBook(this));
         currentStatePointer += 1;
     }
 
+    /**
+     * Reverts the address book to its previous state.
+     */
     public void undo() {
         currentStatePointer -= 1;
         resetData(addressBookStateList.get(currentStatePointer));
     }
 
+    /**
+     * Checks whether the address book can be reverted to a previous state.
+     * @return true if there is a previous state to revert to, else false.
+     */
     public boolean canUndo() {
         if (currentStatePointer <= 0) {
             // cannot undo, no more address book behind the list.
@@ -34,11 +51,18 @@ public class VersionedAddressBook extends AddressBook {
         return true;
     }
 
+    /**
+     * Advances the address book to its next state if possible.
+     */
     public void redo() {
         currentStatePointer += 1;
         resetData(addressBookStateList.get(currentStatePointer));
     }
 
+    /**
+     * Checks whether the address book can be advanced to a next state.
+     * @return true if here is a next state to advance to, else false.
+     */
     public boolean canRedo() {
         if (currentStatePointer >= addressBookStateList.size() - 1) {
             // cannot redo, no more address book in front of list.
@@ -47,6 +71,9 @@ public class VersionedAddressBook extends AddressBook {
         return true;
     }
 
+    /**
+     * Updates the sublist of address book states up to the current state pointer.
+     */
     private void updateSubAddressBookStateList() {
         ArrayList<ReadOnlyAddressBook> copy = new ArrayList<>();
 

--- a/src/main/java/seedu/address/model/VersionedAddressBook.java
+++ b/src/main/java/seedu/address/model/VersionedAddressBook.java
@@ -1,0 +1,77 @@
+package seedu.address.model;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+
+public class VersionedAddressBook extends AddressBook {
+    private ArrayList<ReadOnlyAddressBook> addressBookStateList ;
+    int currentStatePointer;
+
+    public VersionedAddressBook(ReadOnlyAddressBook addressBook) {
+        super(addressBook);
+
+        addressBookStateList = new ArrayList<>();
+        addressBookStateList.add(new AddressBook(addressBook));
+        currentStatePointer = 0;
+    }
+
+    public void commit() {
+        updateSubAddressBookStateList();
+        this.addressBookStateList.add(new AddressBook(this));
+        currentStatePointer += 1;
+    }
+
+    public void undo() {
+        currentStatePointer -= 1;
+        resetData(addressBookStateList.get(currentStatePointer));
+    }
+
+    public boolean canUndo() {
+        if (currentStatePointer <= 0) {
+            // cannot undo, no more address book behind the list.
+            return false;
+        }
+        return true;
+    }
+
+    public void redo() {
+        currentStatePointer += 1;
+        resetData(addressBookStateList.get(currentStatePointer));
+    }
+
+    public boolean canRedo() {
+        if (currentStatePointer >= addressBookStateList.size() - 1) {
+            // cannot redo, no more address book in front of list.
+            return false;
+        }
+        return true;
+    }
+
+    private void updateSubAddressBookStateList() {
+        ArrayList<ReadOnlyAddressBook> copy = new ArrayList<>();
+
+        for (int i = 0; i <= currentStatePointer; i++) {
+            copy.add(addressBookStateList.get(i));
+        }
+
+        this.addressBookStateList = copy;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof VersionedAddressBook)) {
+            return false;
+        }
+
+        VersionedAddressBook otherAddressBook = (VersionedAddressBook) other;
+        return super.equals(otherAddressBook)
+                && addressBookStateList.equals(otherAddressBook.addressBookStateList)
+                && currentStatePointer == otherAddressBook.currentStatePointer;
+    }
+
+}

--- a/src/main/java/seedu/address/model/VersionedAddressBook.java
+++ b/src/main/java/seedu/address/model/VersionedAddressBook.java
@@ -1,14 +1,13 @@
 package seedu.address.model;
 
-import java.lang.reflect.Array;
 import java.util.ArrayList;
 
 /**
  * Extended version of Address Book storing History of Address Book.
  */
 public class VersionedAddressBook extends AddressBook {
-    private ArrayList<ReadOnlyAddressBook> addressBookStateList ;
-    int currentStatePointer;
+    private ArrayList<ReadOnlyAddressBook> addressBookStateList;
+    private int currentStatePointer;
 
     /**
      * Creates VersionedAddressBook and initialize addressBookStateList to track history.

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -199,12 +199,12 @@ class JsonAdaptedPerson {
                     modelSkill, modelCommission);
         }
 
-        if (note == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Note.class.getSimpleName()));
-        }
-        if (!Note.isValidNote(note)) {
-            throw new IllegalValueException(Note.MESSAGE_CONSTRAINTS);
-        }
+//        if (note == null) {
+//            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Note.class.getSimpleName()));
+//        }
+//        if (!Note.isValidNote(note)) {
+//            throw new IllegalValueException(Note.MESSAGE_CONSTRAINTS);
+//        }
         final Note modelNote = new Note(note);
 
         return new Person(modelName, modelPhone, modelEmail, modelAddress, modelNote, modelTags);

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -199,12 +199,12 @@ class JsonAdaptedPerson {
                     modelSkill, modelCommission);
         }
 
-//        if (note == null) {
-//            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Note.class.getSimpleName()));
-//        }
-//        if (!Note.isValidNote(note)) {
-//            throw new IllegalValueException(Note.MESSAGE_CONSTRAINTS);
-//        }
+        if (note == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Note.class.getSimpleName()));
+        }
+        if (!Note.isValidNote(note)) {
+            throw new IllegalValueException(Note.MESSAGE_CONSTRAINTS);
+        }
         final Note modelNote = new Note(note);
 
         return new Person(modelName, modelPhone, modelEmail, modelAddress, modelNote, modelTags);

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -1,35 +1,21 @@
 package seedu.address.logic.commands;
 
-import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
-import javafx.collections.ObservableList;
-import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.messages.AddMessages;
 import seedu.address.logic.stubs.ModelStub;
 import seedu.address.logic.stubs.ModelStubAcceptingPersonAdded;
 import seedu.address.logic.stubs.ModelStubWithPerson;
-import seedu.address.model.AddressBook;
-import seedu.address.model.Model;
-import seedu.address.model.ReadOnlyAddressBook;
-import seedu.address.model.ReadOnlyUserPrefs;
-import seedu.address.model.person.Maintainer;
-import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.Staff;
-import seedu.address.model.person.Supplier;
 import seedu.address.testutil.PersonBuilder;
 
 public class AddCommandTest {

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -18,6 +18,9 @@ import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.messages.AddMessages;
+import seedu.address.logic.stubs.ModelStub;
+import seedu.address.logic.stubs.ModelStubAcceptingPersonAdded;
+import seedu.address.logic.stubs.ModelStubWithPerson;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
@@ -89,141 +92,10 @@ public class AddCommandTest {
         assertEquals(expected, addCommand.toString());
     }
 
-    /**
-     * A default model stub that have all of the methods failing.
-     */
-    private class ModelStub implements Model {
-        @Override
-        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-            throw new AssertionError("This method should not be called.");
-        }
 
-        @Override
-        public ReadOnlyUserPrefs getUserPrefs() {
-            throw new AssertionError("This method should not be called.");
-        }
 
-        @Override
-        public GuiSettings getGuiSettings() {
-            throw new AssertionError("This method should not be called.");
-        }
 
-        @Override
-        public void setGuiSettings(GuiSettings guiSettings) {
-            throw new AssertionError("This method should not be called.");
-        }
 
-        @Override
-        public Path getAddressBookFilePath() {
-            throw new AssertionError("This method should not be called.");
-        }
 
-        @Override
-        public void setAddressBookFilePath(Path addressBookFilePath) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addPerson(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setAddressBook(ReadOnlyAddressBook newData) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyAddressBook getAddressBook() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasPerson(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deletePerson(Person target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setPerson(Person target, Person editedPerson) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Person> getFilteredPersonList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredPersonList(Predicate<Person> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Person findByName(Name targetName) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Maintainer findMaintainerByName(Name targetName) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Supplier findSupplierByName(Name targetName) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Staff findStaffByName(Name targetName) {
-            throw new AssertionError("This method should not be called.");
-        }
-    }
-
-    /**
-     * A Model stub that contains a single person.
-     */
-    private class ModelStubWithPerson extends ModelStub {
-        private final Person person;
-
-        ModelStubWithPerson(Person person) {
-            requireNonNull(person);
-            this.person = person;
-        }
-
-        @Override
-        public boolean hasPerson(Person person) {
-            requireNonNull(person);
-            return this.person.isSamePerson(person);
-        }
-    }
-
-    /**
-     * A Model stub that always accept the person being added.
-     */
-    private class ModelStubAcceptingPersonAdded extends ModelStub {
-        final ArrayList<Person> personsAdded = new ArrayList<>();
-
-        @Override
-        public boolean hasPerson(Person person) {
-            requireNonNull(person);
-            return personsAdded.stream().anyMatch(person::isSamePerson);
-        }
-
-        @Override
-        public void addPerson(Person person) {
-            requireNonNull(person);
-            personsAdded.add(person);
-        }
-
-        @Override
-        public ReadOnlyAddressBook getAddressBook() {
-            return new AddressBook();
-        }
-    }
 
 }

--- a/src/test/java/seedu/address/logic/commands/AddMaintainerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddMaintainerCommandTest.java
@@ -18,6 +18,9 @@ import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.messages.AddMessages;
+import seedu.address.logic.stubs.ModelStub;
+import seedu.address.logic.stubs.ModelStubAcceptingPersonAdded;
+import seedu.address.logic.stubs.ModelStubWithPerson;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
@@ -88,143 +91,6 @@ public class AddMaintainerCommandTest {
         String expected = AddMaintainerCommand.class.getCanonicalName()
                 + "{toAdd=" + ALICEMAINTAINER + "}";
         assertEquals(expected, addCommand.toString());
-    }
-
-    /**
-     * A default model stub that have all of the methods failing.
-     */
-    private class ModelStub implements Model {
-        @Override
-        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyUserPrefs getUserPrefs() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public GuiSettings getGuiSettings() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setGuiSettings(GuiSettings guiSettings) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Path getAddressBookFilePath() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setAddressBookFilePath(Path addressBookFilePath) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addPerson(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setAddressBook(ReadOnlyAddressBook newData) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyAddressBook getAddressBook() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasPerson(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deletePerson(Person target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setPerson(Person target, Person editedPerson) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Person> getFilteredPersonList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredPersonList(Predicate<Person> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Person findByName(Name targetName) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Maintainer findMaintainerByName(Name targetName) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Supplier findSupplierByName(Name targetName) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Staff findStaffByName(Name targetName) {
-            throw new AssertionError("This method should not be called.");
-        }
-    }
-
-    /**
-     * A Model stub that contains a single person.
-     */
-    private class ModelStubWithPerson extends ModelStub {
-        private final Person person;
-
-        ModelStubWithPerson(Person person) {
-            requireNonNull(person);
-            this.person = person;
-        }
-
-        @Override
-        public boolean hasPerson(Person person) {
-            requireNonNull(person);
-            return this.person.isSamePerson(person);
-        }
-    }
-
-    /**
-     * A Model stub that always accept the person being added.
-     */
-    private class ModelStubAcceptingPersonAdded extends ModelStub {
-        final ArrayList<Person> personsAdded = new ArrayList<>();
-
-        @Override
-        public boolean hasPerson(Person person) {
-            requireNonNull(person);
-            return personsAdded.stream().anyMatch(person::isSamePerson);
-        }
-
-        @Override
-        public void addPerson(Person person) {
-            requireNonNull(person);
-            personsAdded.add(person);
-        }
-
-        @Override
-        public ReadOnlyAddressBook getAddressBook() {
-            return new AddressBook();
-        }
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/AddMaintainerCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddMaintainerCommandTest.java
@@ -1,35 +1,21 @@
 package seedu.address.logic.commands;
 
-import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICEMAINTAINER;
 
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
-import javafx.collections.ObservableList;
-import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.messages.AddMessages;
 import seedu.address.logic.stubs.ModelStub;
 import seedu.address.logic.stubs.ModelStubAcceptingPersonAdded;
 import seedu.address.logic.stubs.ModelStubWithPerson;
-import seedu.address.model.AddressBook;
-import seedu.address.model.Model;
-import seedu.address.model.ReadOnlyAddressBook;
-import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.person.Maintainer;
-import seedu.address.model.person.Name;
-import seedu.address.model.person.Person;
-import seedu.address.model.person.Staff;
-import seedu.address.model.person.Supplier;
 import seedu.address.testutil.MaintainerBuilder;
 
 public class AddMaintainerCommandTest {

--- a/src/test/java/seedu/address/logic/commands/AddStaffCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddStaffCommandTest.java
@@ -1,35 +1,21 @@
 package seedu.address.logic.commands;
 
-import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICESTAFF;
 
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
-import javafx.collections.ObservableList;
-import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.messages.AddMessages;
 import seedu.address.logic.stubs.ModelStub;
 import seedu.address.logic.stubs.ModelStubAcceptingPersonAdded;
 import seedu.address.logic.stubs.ModelStubWithPerson;
-import seedu.address.model.AddressBook;
-import seedu.address.model.Model;
-import seedu.address.model.ReadOnlyAddressBook;
-import seedu.address.model.ReadOnlyUserPrefs;
-import seedu.address.model.person.Maintainer;
-import seedu.address.model.person.Name;
-import seedu.address.model.person.Person;
 import seedu.address.model.person.Staff;
-import seedu.address.model.person.Supplier;
 import seedu.address.testutil.StaffBuilder;
 
 public class AddStaffCommandTest {

--- a/src/test/java/seedu/address/logic/commands/AddStaffCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddStaffCommandTest.java
@@ -18,6 +18,9 @@ import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.messages.AddMessages;
+import seedu.address.logic.stubs.ModelStub;
+import seedu.address.logic.stubs.ModelStubAcceptingPersonAdded;
+import seedu.address.logic.stubs.ModelStubWithPerson;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
@@ -87,143 +90,6 @@ public class AddStaffCommandTest {
         AddStaffCommand addCommand = new AddStaffCommand(ALICESTAFF);
         String expected = AddStaffCommand.class.getCanonicalName() + "{toAdd=" + ALICESTAFF + "}";
         assertEquals(expected, addCommand.toString());
-    }
-
-    /**
-     * A default model stub that have all of the methods failing.
-     */
-    private class ModelStub implements Model {
-        @Override
-        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyUserPrefs getUserPrefs() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public GuiSettings getGuiSettings() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setGuiSettings(GuiSettings guiSettings) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Path getAddressBookFilePath() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setAddressBookFilePath(Path addressBookFilePath) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addPerson(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setAddressBook(ReadOnlyAddressBook newData) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyAddressBook getAddressBook() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasPerson(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deletePerson(Person target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setPerson(Person target, Person editedPerson) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Person> getFilteredPersonList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredPersonList(Predicate<Person> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Person findByName(Name targetName) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Maintainer findMaintainerByName(Name targetName) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Supplier findSupplierByName(Name targetName) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Staff findStaffByName(Name targetName) {
-            throw new AssertionError("This method should not be called.");
-        }
-    }
-
-    /**
-     * A Model stub that contains a single person.
-     */
-    private class ModelStubWithPerson extends ModelStub {
-        private final Person person;
-
-        ModelStubWithPerson(Person person) {
-            requireNonNull(person);
-            this.person = person;
-        }
-
-        @Override
-        public boolean hasPerson(Person person) {
-            requireNonNull(person);
-            return this.person.isSamePerson(person);
-        }
-    }
-
-    /**
-     * A Model stub that always accept the person being added.
-     */
-    private class ModelStubAcceptingPersonAdded extends ModelStub {
-        final ArrayList<Person> personsAdded = new ArrayList<>();
-
-        @Override
-        public boolean hasPerson(Person person) {
-            requireNonNull(person);
-            return personsAdded.stream().anyMatch(person::isSamePerson);
-        }
-
-        @Override
-        public void addPerson(Person person) {
-            requireNonNull(person);
-            personsAdded.add(person);
-        }
-
-        @Override
-        public ReadOnlyAddressBook getAddressBook() {
-            return new AddressBook();
-        }
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/AddSupplierCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddSupplierCommandTest.java
@@ -1,34 +1,20 @@
 package seedu.address.logic.commands;
 
-import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICESUPPLIER;
 
-import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
-import javafx.collections.ObservableList;
-import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.messages.AddMessages;
 import seedu.address.logic.stubs.ModelStub;
 import seedu.address.logic.stubs.ModelStubAcceptingPersonAdded;
 import seedu.address.logic.stubs.ModelStubWithPerson;
-import seedu.address.model.AddressBook;
-import seedu.address.model.Model;
-import seedu.address.model.ReadOnlyAddressBook;
-import seedu.address.model.ReadOnlyUserPrefs;
-import seedu.address.model.person.Maintainer;
-import seedu.address.model.person.Name;
-import seedu.address.model.person.Person;
-import seedu.address.model.person.Staff;
 import seedu.address.model.person.Supplier;
 import seedu.address.testutil.SupplierBuilder;
 

--- a/src/test/java/seedu/address/logic/commands/AddSupplierCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddSupplierCommandTest.java
@@ -18,6 +18,9 @@ import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.messages.AddMessages;
+import seedu.address.logic.stubs.ModelStub;
+import seedu.address.logic.stubs.ModelStubAcceptingPersonAdded;
+import seedu.address.logic.stubs.ModelStubWithPerson;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
@@ -87,143 +90,6 @@ public class AddSupplierCommandTest {
         AddSupplierCommand addCommand = new AddSupplierCommand(ALICESUPPLIER);
         String expected = AddSupplierCommand.class.getCanonicalName() + "{toAdd=" + ALICESUPPLIER + "}";
         assertEquals(expected, addCommand.toString());
-    }
-
-    /**
-     * A default model stub that have all of the methods failing.
-     */
-    private class ModelStub implements Model {
-        @Override
-        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyUserPrefs getUserPrefs() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public GuiSettings getGuiSettings() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setGuiSettings(GuiSettings guiSettings) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Path getAddressBookFilePath() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setAddressBookFilePath(Path addressBookFilePath) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addPerson(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setAddressBook(ReadOnlyAddressBook newData) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyAddressBook getAddressBook() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasPerson(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deletePerson(Person target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setPerson(Person target, Person editedPerson) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Person> getFilteredPersonList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredPersonList(Predicate<Person> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Person findByName(Name targetName) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Maintainer findMaintainerByName(Name targetName) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Supplier findSupplierByName(Name targetName) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Staff findStaffByName(Name targetName) {
-            throw new AssertionError("This method should not be called.");
-        }
-    }
-
-    /**
-     * A Model stub that contains a single person.
-     */
-    private class ModelStubWithPerson extends ModelStub {
-        private final Person person;
-
-        ModelStubWithPerson(Person person) {
-            requireNonNull(person);
-            this.person = person;
-        }
-
-        @Override
-        public boolean hasPerson(Person person) {
-            requireNonNull(person);
-            return this.person.isSamePerson(person);
-        }
-    }
-
-    /**
-     * A Model stub that always accept the person being added.
-     */
-    private class ModelStubAcceptingPersonAdded extends ModelStub {
-        final ArrayList<Person> personsAdded = new ArrayList<>();
-
-        @Override
-        public boolean hasPerson(Person person) {
-            requireNonNull(person);
-            return personsAdded.stream().anyMatch(person::isSamePerson);
-        }
-
-        @Override
-        public void addPerson(Person person) {
-            requireNonNull(person);
-            personsAdded.add(person);
-        }
-
-        @Override
-        public ReadOnlyAddressBook getAddressBook() {
-            return new AddressBook();
-        }
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -16,6 +16,7 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalPersons.getTypicalVersionedAddressBook;
 
 import org.junit.jupiter.api.Test;
 
@@ -26,6 +27,7 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.VersionedAddressBook;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
@@ -75,19 +77,18 @@ public class EditCommandTest {
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
-    // failed because address book is different, original model address book have two states
-    // expected model only have one state.
     @Test
-    public void execute_noFieldSpecifiedUnfilteredList_success() {
+    public void execute_noFieldSpecifiedUnfilteredList_success() throws Exception {
         EditCommand editCommand = new EditCommand(ALICE.getName(), new EditPersonDescriptor());
         Person editedPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
 
         String expectedMessage = String.format(EditMessages.MESSAGE_EDIT_PERSON_SUCCESS,
                 EditMessages.format(editedPerson));
 
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        editCommand.execute(model);
+        AddressBook addressBookCopy = new VersionedAddressBook(model.getAddressBook());
 
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        assertEquals(getTypicalVersionedAddressBook(), addressBookCopy);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -75,6 +75,8 @@ public class EditCommandTest {
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
 
+    // failed because address book is different, original model address book have two states
+    // expected model only have one state.
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
         EditCommand editCommand = new EditCommand(ALICE.getName(), new EditPersonDescriptor());

--- a/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
@@ -1,0 +1,65 @@
+package seedu.address.logic.commands;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.messages.RedoMessages;
+import seedu.address.logic.messages.UndoMessages;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+public class RedoCommandTest {
+
+    @Test
+    public void execute_redoSuccessful() throws Exception {
+        Model modelManager = new ModelManager(new AddressBook(getTypicalAddressBook()), new UserPrefs());
+        Person validPerson = new PersonBuilder().build();
+
+        new AddCommand(validPerson).execute(modelManager);
+        new UndoCommand().execute(modelManager);
+        RedoCommand redoCommand = new RedoCommand();
+        CommandResult redoCommandResult = redoCommand.execute(modelManager);
+        assertEquals(RedoMessages.MESSAGE_REDO_SUCCESS, redoCommandResult.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_impossibleRedoState_throwsCommandException() {
+        Model modelManager = new ModelManager(new AddressBook(getTypicalAddressBook()), new UserPrefs());
+        RedoCommand redoCommand = new RedoCommand();
+
+        assertThrows(CommandException.class,
+                RedoMessages.MESSAGE_REDO_FAIL, () -> redoCommand.execute(modelManager));
+    }
+
+    @Test
+    public void equals() {
+        RedoCommand firstRedoCommand = new RedoCommand();
+        RedoCommand secondRedoCommand = new RedoCommand();
+
+        // same object -> returns true
+        assertTrue(firstRedoCommand.equals(secondRedoCommand));
+
+        // different types -> returns false
+        assertFalse(firstRedoCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(firstRedoCommand.equals(null));
+    }
+
+    @Test
+    public void toStringMethod() {
+        RedoCommand redoCommand = new RedoCommand();
+        String expected = RedoCommand.class.getCanonicalName() + "{}";
+        assertEquals(expected, redoCommand.toString());
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
@@ -1,21 +1,21 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
 import org.junit.jupiter.api.Test;
+
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.messages.RedoMessages;
-import seedu.address.logic.messages.UndoMessages;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.PersonBuilder;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 public class RedoCommandTest {
 

--- a/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
@@ -1,0 +1,71 @@
+package seedu.address.logic.commands;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.messages.AddMessages;
+import seedu.address.logic.messages.UndoMessages;
+import seedu.address.logic.stubs.ModelStub;
+import seedu.address.logic.stubs.ModelStubAcceptingPersonAdded;
+import seedu.address.logic.stubs.ModelStubWithPerson;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+public class UndoCommandTest {
+
+    @Test
+    public void execute_undoSuccessful() throws Exception {
+        Model modelManager = new ModelManager(new AddressBook(getTypicalAddressBook()), new UserPrefs());
+        Person validPerson = new PersonBuilder().build();
+
+        new AddCommand(validPerson).execute(modelManager);
+        UndoCommand undoCommand = new UndoCommand();
+
+        CommandResult undoCommandResult = undoCommand.execute(modelManager);
+        assertEquals(UndoMessages.MESSAGE_UNDO_SUCCESS, undoCommandResult.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_impossibleUndoState_throwsCommandException() {
+        Model modelManager = new ModelManager(new AddressBook(getTypicalAddressBook()), new UserPrefs());
+        UndoCommand undoCommand = new UndoCommand();
+
+        assertThrows(CommandException.class,
+                UndoMessages.MESSAGE_UNDO_FAIL, () -> undoCommand.execute(modelManager));
+    }
+
+    @Test
+    public void equals() {
+        UndoCommand firstUndoCommand = new UndoCommand();
+        UndoCommand secondUndoCommand = new UndoCommand();
+
+        // same object -> returns true
+        assertTrue(firstUndoCommand.equals(secondUndoCommand));
+
+        // different types -> returns false
+        assertFalse(firstUndoCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(firstUndoCommand.equals(null));
+    }
+
+    @Test
+    public void toStringMethod() {
+        UndoCommand undoCommand = new UndoCommand();
+        String expected = UndoCommand.class.getCanonicalName() + "{}";
+        assertEquals(expected, undoCommand.toString());
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
@@ -1,12 +1,15 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
 import org.junit.jupiter.api.Test;
+
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.logic.messages.AddMessages;
 import seedu.address.logic.messages.UndoMessages;
-import seedu.address.logic.stubs.ModelStub;
-import seedu.address.logic.stubs.ModelStubAcceptingPersonAdded;
-import seedu.address.logic.stubs.ModelStubWithPerson;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -14,14 +17,6 @@ import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.PersonBuilder;
 
-import java.util.Arrays;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalPersons.ALICE;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 public class UndoCommandTest {
 

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.COMMISSION_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
@@ -19,7 +20,9 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.messages.Messages.MESSAGE_COMMAND_FORMAT;
 import static seedu.address.logic.messages.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.messages.Messages.MESSAGE_INVALID_FIELD_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -188,5 +191,14 @@ public class AddCommandParserTest {
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                 + ADDRESS_DESC_BOB,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidField_failure() {
+        String exception = String.format(MESSAGE_INVALID_FIELD_FORMAT, "; commission :");
+        exception += "\n" + String.format(MESSAGE_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, NAME_DESC_BOB + COMMISSION_DESC_BOB + PHONE_DESC_BOB
+                        + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
+                exception);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddMaintainerCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddMaintainerCommandParserTest.java
@@ -18,6 +18,7 @@ import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.address.logic.commands.CommandTestUtil.SALARY_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.SKILL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.SKILL_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
@@ -26,7 +27,9 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_SKILL_BOB;
+import static seedu.address.logic.messages.Messages.MESSAGE_COMMAND_FORMAT;
 import static seedu.address.logic.messages.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.messages.Messages.MESSAGE_INVALID_FIELD_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COMMISSION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
@@ -224,5 +227,14 @@ public class AddMaintainerCommandParserTest {
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                 + ADDRESS_DESC_BOB + SKILL_DESC_BOB + COMMISSION_DESC_BOB,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddMaintainerCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidField_failure() {
+        String exception = String.format(MESSAGE_INVALID_FIELD_FORMAT, "; salary :");
+        exception += "\n" + String.format(MESSAGE_COMMAND_FORMAT, AddMaintainerCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, NAME_DESC_BOB + SALARY_DESC_BOB + PHONE_DESC_BOB
+                        + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + COMMISSION_DESC_BOB + SKILL_DESC_BOB,
+                exception);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddStaffCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddStaffCommandParserTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.COMMISSION_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.EMPLOYMENT_DESC_AMY;
@@ -27,7 +28,9 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_EMPLOYMENT_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_SALARY_BOB;
+import static seedu.address.logic.messages.Messages.MESSAGE_COMMAND_FORMAT;
 import static seedu.address.logic.messages.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.messages.Messages.MESSAGE_INVALID_FIELD_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMPLOYMENT;
@@ -220,5 +223,14 @@ public class AddStaffCommandParserTest {
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                 + ADDRESS_DESC_BOB + SALARY_DESC_BOB + EMPLOYMENT_DESC_BOB,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddStaffCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidField_failure() {
+        String exception = String.format(MESSAGE_INVALID_FIELD_FORMAT, "; commission :");
+        exception += "\n" + String.format(MESSAGE_COMMAND_FORMAT, AddStaffCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, NAME_DESC_BOB + COMMISSION_DESC_BOB + PHONE_DESC_BOB
+                        + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + SALARY_DESC_BOB + EMPLOYMENT_DESC_BOB,
+                exception);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddSupplierCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddSupplierCommandParserTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.COMMISSION_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
@@ -26,7 +27,9 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PRICE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PRODUCT_BOB;
+import static seedu.address.logic.messages.Messages.MESSAGE_COMMAND_FORMAT;
 import static seedu.address.logic.messages.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.messages.Messages.MESSAGE_INVALID_FIELD_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -222,5 +225,14 @@ public class AddSupplierCommandParserTest {
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                 + ADDRESS_DESC_BOB + PRODUCT_DESC_BOB + PRICE_DESC_BOB,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddSupplierCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidField_failure() {
+        String exception = String.format(MESSAGE_INVALID_FIELD_FORMAT, "; commission :");
+        exception += "\n" + String.format(MESSAGE_COMMAND_FORMAT, AddSupplierCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, NAME_DESC_BOB + COMMISSION_DESC_BOB + PHONE_DESC_BOB
+                        + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + PRODUCT_DESC_BOB + PRICE_DESC_BOB,
+                exception);
     }
 }

--- a/src/test/java/seedu/address/logic/stubs/ModelStub.java
+++ b/src/test/java/seedu/address/logic/stubs/ModelStub.java
@@ -1,5 +1,8 @@
 package seedu.address.logic.stubs;
 
+import java.nio.file.Path;
+import java.util.function.Predicate;
+
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.Model;
@@ -10,9 +13,6 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Staff;
 import seedu.address.model.person.Supplier;
-
-import java.nio.file.Path;
-import java.util.function.Predicate;
 
 /**
  * A default model stub that have all of the methods failing.
@@ -132,4 +132,5 @@ public class ModelStub implements Model {
     public void redoAddressBook() {
         throw new AssertionError("This method should not be called.");
     }
+
 }

--- a/src/test/java/seedu/address/logic/stubs/ModelStub.java
+++ b/src/test/java/seedu/address/logic/stubs/ModelStub.java
@@ -1,0 +1,135 @@
+package seedu.address.logic.stubs;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.Model;
+import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.person.Maintainer;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Staff;
+import seedu.address.model.person.Supplier;
+
+import java.nio.file.Path;
+import java.util.function.Predicate;
+
+/**
+ * A default model stub that have all of the methods failing.
+ */
+public class ModelStub implements Model {
+    @Override
+    public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ReadOnlyUserPrefs getUserPrefs() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public GuiSettings getGuiSettings() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setGuiSettings(GuiSettings guiSettings) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public Path getAddressBookFilePath() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setAddressBookFilePath(Path addressBookFilePath) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addPerson(Person person) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setAddressBook(ReadOnlyAddressBook newData) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ReadOnlyAddressBook getAddressBook() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasPerson(Person person) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void deletePerson(Person target) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setPerson(Person target, Person editedPerson) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Person> getFilteredPersonList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void updateFilteredPersonList(Predicate<Person> predicate) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public Person findByName(Name targetName) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public Maintainer findMaintainerByName(Name targetName) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public Supplier findSupplierByName(Name targetName) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public Staff findStaffByName(Name targetName) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean canRedo() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean canUndo() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void commitAddressBook() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void undoAddressBook() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void redoAddressBook() {
+        throw new AssertionError("This method should not be called.");
+    }
+}

--- a/src/test/java/seedu/address/logic/stubs/ModelStubAcceptingPersonAdded.java
+++ b/src/test/java/seedu/address/logic/stubs/ModelStubAcceptingPersonAdded.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.stubs;
+
+import seedu.address.model.AddressBook;
+import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.person.Person;
+
+import java.util.ArrayList;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A Model stub that always accept the person being added.
+ */
+public class ModelStubAcceptingPersonAdded extends ModelStub {
+    public final ArrayList<Person> personsAdded = new ArrayList<>();
+
+    @Override
+    public boolean hasPerson(Person person) {
+        requireNonNull(person);
+        return personsAdded.stream().anyMatch(person::isSamePerson);
+    }
+
+    @Override
+    public void addPerson(Person person) {
+        requireNonNull(person);
+        personsAdded.add(person);
+    }
+
+    @Override
+    public ReadOnlyAddressBook getAddressBook() {
+        return new AddressBook();
+    }
+}

--- a/src/test/java/seedu/address/logic/stubs/ModelStubAcceptingPersonAdded.java
+++ b/src/test/java/seedu/address/logic/stubs/ModelStubAcceptingPersonAdded.java
@@ -1,12 +1,12 @@
 package seedu.address.logic.stubs;
 
-import seedu.address.model.AddressBook;
-import seedu.address.model.ReadOnlyAddressBook;
-import seedu.address.model.person.Person;
+import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
 
-import static java.util.Objects.requireNonNull;
+import seedu.address.model.AddressBook;
+import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.person.Person;
 
 /**
  * A Model stub that always accept the person being added.

--- a/src/test/java/seedu/address/logic/stubs/ModelStubWithPerson.java
+++ b/src/test/java/seedu/address/logic/stubs/ModelStubWithPerson.java
@@ -1,8 +1,8 @@
 package seedu.address.logic.stubs;
 
-import seedu.address.model.person.Person;
-
 import static java.util.Objects.requireNonNull;
+
+import seedu.address.model.person.Person;
 
 /**
  * A Model stub that contains a single person.
@@ -10,6 +10,10 @@ import static java.util.Objects.requireNonNull;
 public class ModelStubWithPerson extends ModelStub {
     private final Person person;
 
+    /**
+     * Creates ModelStubWithPerson.
+     * @param person
+     */
     public ModelStubWithPerson(Person person) {
         requireNonNull(person);
         this.person = person;
@@ -20,4 +24,5 @@ public class ModelStubWithPerson extends ModelStub {
         requireNonNull(person);
         return this.person.isSamePerson(person);
     }
+
 }

--- a/src/test/java/seedu/address/logic/stubs/ModelStubWithPerson.java
+++ b/src/test/java/seedu/address/logic/stubs/ModelStubWithPerson.java
@@ -1,0 +1,23 @@
+package seedu.address.logic.stubs;
+
+import seedu.address.model.person.Person;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A Model stub that contains a single person.
+ */
+public class ModelStubWithPerson extends ModelStub {
+    private final Person person;
+
+    public ModelStubWithPerson(Person person) {
+        requireNonNull(person);
+        this.person = person;
+    }
+
+    @Override
+    public boolean hasPerson(Person person) {
+        requireNonNull(person);
+        return this.person.isSamePerson(person);
+    }
+}

--- a/src/test/java/seedu/address/model/VersionedAddressBookTest.java
+++ b/src/test/java/seedu/address/model/VersionedAddressBookTest.java
@@ -1,0 +1,64 @@
+package seedu.address.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+public class VersionedAddressBookTest {
+
+    private final VersionedAddressBook addressBook = new VersionedAddressBook(getTypicalAddressBook());
+
+    @Test
+    public void canUndoMethod() {
+        assertEquals(false, addressBook.canUndo());
+        addressBook.commit();
+        assertEquals(true, addressBook.canUndo());
+    }
+
+    @Test
+    public void canRedoMethod() {
+        assertEquals(false, addressBook.canRedo());
+        addressBook.commit();
+        addressBook.undo();
+        assertEquals(true, addressBook.canRedo());
+    }
+
+    @Test
+    public void toStringMethod() {
+        String expected = VersionedAddressBook.class.getCanonicalName()
+                + "{persons=" + addressBook.getPersonList() + "}";
+        assertEquals(expected, addressBook.toString());
+    }
+
+    @Test
+    public void equals() {
+        VersionedAddressBook b1 = new VersionedAddressBook(getTypicalAddressBook());
+        VersionedAddressBook b2 = new VersionedAddressBook(getTypicalAddressBook());
+
+        // same object -> returns true
+        assertTrue(b1.equals(b2));
+
+        // different types -> returns false
+        assertFalse(b1.equals(1));
+
+        // null -> returns false
+        assertFalse(b1.equals(null));
+
+        b1.commit();
+        // different history and different pointer -> return false
+        assertFalse(b1.equals(b2));
+
+        b1.undo();
+        // same history and different pointer -> return false
+        assertFalse(b1.equals(b2));
+
+        b2.commit();
+        b2.undo();
+        // same history and same pointer -> return true
+        assertTrue(b1.equals(b2));
+    }
+
+}

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import seedu.address.model.AddressBook;
+import seedu.address.model.VersionedAddressBook;
 import seedu.address.model.person.Maintainer;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Staff;
@@ -139,6 +140,14 @@ public class TypicalPersons {
         for (Person person : getTypicalPersons()) {
             ab.addPerson(person);
         }
+        return ab;
+    }
+
+    /**
+     * Returns an {@code AddressBook} with all the typical persons.
+     */
+    public static AddressBook getTypicalVersionedAddressBook() {
+        AddressBook ab = new VersionedAddressBook(getTypicalAddressBook());
         return ab;
     }
 


### PR DESCRIPTION
Fixes #89 
Fixes #95 
Fixes #97 
Fixes #110 
Fixes #111 

### New function in ArgumentTokenizer : checkUnknownPrefix(String, Prefix...)
- This function will **return the unknown prefix as string**
- Updated on **catching unknown prefix in Add Commands**
- Developers can repeatedly **use this function to catch unknown prefix** on each of the Command.

### New Command : Undo and Redo
- **UndoCommand and RedoCommand** classes are created to support undo and redo operation. 

### Changes on Address Book
- Original Address Book doesnt store any version.
- Created **new class VersionedAddressBook extends from AddressBook class**
- VersionedAddressBook will **keep a new state into History Tracker** whenever addCommand, editCommand, deleteCommand are called. 
- VersionedAddressBook will keep track of state in an array, **by shifting the pointer on the History Tracker** which will allow undo / redo command to be executed.

### Changes on ModelManager
- ModelManager will **contain VersionedAddressBook instead of AddressBook**
- New operations supported by ModelManager : **commitAddressBook(), undoAddressBook, redoAddressBook(), canUndo(), canRedo().**
- Whenever **modification is done on address book** (such as add / edit / delete), ModelManager will **execute** **commitAddressBook()** in order to **store new state into VersionedAddressBook.**
- When **at least one commit** is done on addressbook, **undo command only able to execute**. The validity of the execution will be checked by using canUndo().
- When **at least one undo** is done on addressbook, **redo command only able to execute**. The validify of the execution will be checked by using canRedo().
- Whenever **new commit is done** on addressbook, the **"future state" of address book arised due to undo command will all be refreshed and no longer able to execute redo**. To execute redo, undo command has to be executed at least once from this state.

## Requires Extra Attention from Developers
- During testing, be aware of followings point when using ModelManager and VersionedAddressBook.
- After **any execution** of command, **ModelManager will do** a **commit on VersionedAddressBook**, it will have **different size of History state** as before, and so it is **considered as different VersionedAddressBook** compared to before the execution. 
- Whenever **undo / redo command is executed**, the pointer in VersionedAddressBook is **pointing at different state**, hence it is **considered as different VersionedAddressBook** compared to before the execution. 
