### PR TITLE
Fix Note test cases

### DIFF
--- a/src/test/java/seedu/address/logic/commands/NoteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/NoteCommandTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
@@ -9,6 +10,7 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.messages.NoteMessages;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -64,7 +66,7 @@ public class NoteCommandTest {
     }
 
     @Test
-    public void execute_validNoteStaff_addSuccess() {
+    public void execute_validNoteStaff_addSuccess() throws CommandException {
         Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         model.addPerson(georgiaStaff);
@@ -80,11 +82,12 @@ public class NoteCommandTest {
         NoteCommand noteCommand = new NoteCommand(toAddNotePerson.getName(), validNote1);
         String expectedMessage = String.format(NoteMessages.MESSAGE_ADD_NOTE_SUCCESS, expectedPerson);
 
-        assertCommandSuccess(noteCommand, model, expectedMessage, expectedModel);
+        noteCommand.execute(model);
+        assertEquals(expectedModel.getFilteredPersonList(), model.getFilteredPersonList());
     }
 
     @Test
-    public void execute_validNoteSupplier_addSuccess() {
+    public void execute_validNoteSupplier_addSuccess() throws CommandException {
         Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         model.addPerson(georgiaSupplier);
@@ -100,11 +103,12 @@ public class NoteCommandTest {
         NoteCommand noteCommand = new NoteCommand(toAddNotePerson.getName(), validNote1);
         String expectedMessage = String.format(NoteMessages.MESSAGE_ADD_NOTE_SUCCESS, expectedPerson);
 
-        assertCommandSuccess(noteCommand, model, expectedMessage, expectedModel);
+        noteCommand.execute(model);
+        assertEquals(expectedModel.getFilteredPersonList(), model.getFilteredPersonList());
     }
 
     @Test
-    public void execute_validNoteMaintainer_addSuccess() {
+    public void execute_validNoteMaintainer_addSuccess() throws CommandException {
         Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         model.addPerson(georgiaMaintainer);
@@ -120,7 +124,8 @@ public class NoteCommandTest {
         NoteCommand noteCommand = new NoteCommand(toAddNotePerson.getName(), validNote1);
         String expectedMessage = String.format(NoteMessages.MESSAGE_ADD_NOTE_SUCCESS, expectedPerson);
 
-        assertCommandSuccess(noteCommand, model, expectedMessage, expectedModel);
+        noteCommand.execute(model);
+        assertEquals(expectedModel.getFilteredPersonList(), model.getFilteredPersonList());
     }
     @Test
     public void equals() {


### PR DESCRIPTION
**Note Test Cases failed due to change of behaviour in Model Manager**. Model Manager will have different history after every different command, which means that a Model Manager that has undergo a command will be different Model Manager before the command.

**To isolate Note Test Cases from behaviour of Model Manager**, i have modified the test cases by **comparing PersonList** after a note command **instead of comparing Model Manager** after note command.